### PR TITLE
Undefined attributes

### DIFF
--- a/cobald/composite/factory.py
+++ b/cobald/composite/factory.py
@@ -3,7 +3,7 @@ import weakref
 
 import trio
 
-from cobald.interfaces import Pool, CompositePool
+from cobald.interfaces import Pool, CompositePool, PropertyError
 from cobald.daemon import service
 
 
@@ -52,16 +52,16 @@ class FactoryPool(CompositePool):
         active_children = [child for child in self._hatchery if child.supply > 0]
         try:
             return sum(child.utilisation for child in active_children) / len(active_children)
-        except ZeroDivisionError:
-            return 1.
+        except ZeroDivisionError as err:
+            raise PropertyError(self, 'utilisation') from err
 
     @property
     def allocation(self):
         active_children = [child for child in self._hatchery if child.supply > 0]
         try:
             return sum(child.allocation for child in active_children) / len(active_children)
-        except ZeroDivisionError:
-            return 1.
+        except ZeroDivisionError as err:
+            raise PropertyError(self, 'allocation') from err
 
     def __init__(self, *children: Pool, factory: Callable[[], Pool], interval: float = 30):
         self._demand = sum(child.demand for child in children)

--- a/cobald/composite/uniform.py
+++ b/cobald/composite/uniform.py
@@ -1,4 +1,4 @@
-from ..interfaces import Pool, CompositePool
+from ..interfaces import Pool, CompositePool, PropertyError
 
 
 class UniformComposite(CompositePool):
@@ -26,15 +26,15 @@ class UniformComposite(CompositePool):
     def utilisation(self):
         try:
             return sum(child.utilisation for child in self.children) / len(self.children)
-        except ZeroDivisionError:
-            return 1.
+        except ZeroDivisionError as err:
+            raise PropertyError(self, 'utilisation') from err
 
     @property
     def allocation(self):
         try:
             return sum(child.allocation for child in self.children) / len(self.children)
-        except ZeroDivisionError:
-            return 1.
+        except ZeroDivisionError as err:
+            raise PropertyError(self, 'allocation') from err
 
     def __init__(self, *children: Pool):
         self._demand = sum(child.demand for child in children)

--- a/cobald/composite/weighted.py
+++ b/cobald/composite/weighted.py
@@ -1,4 +1,4 @@
-from ..interfaces import Pool, CompositePool
+from ..interfaces import Pool, CompositePool, PropertyError
 
 
 class WeightedComposite(CompositePool):
@@ -30,15 +30,15 @@ class WeightedComposite(CompositePool):
     def utilisation(self):
         try:
             return sum(child.utilisation * child.supply for child in self.children) / self.supply
-        except ZeroDivisionError:
-            return 1.
+        except ZeroDivisionError as err:
+            raise PropertyError(self, 'utilisation') from err
 
     @property
     def allocation(self):
         try:
             return sum(child.allocation * child.supply for child in self.children) / self.supply
-        except ZeroDivisionError:
-            return 1.
+        except ZeroDivisionError as err:
+            raise PropertyError(self, 'allocation') from err
 
     def __init__(self, *children: Pool):
         self._demand = sum(child.demand for child in children)

--- a/cobald/decorator/default.py
+++ b/cobald/decorator/default.py
@@ -1,0 +1,31 @@
+from cobald.interfaces import Pool, PoolDecorator, PropertyError
+
+
+class Default(PoolDecorator):
+    """
+    Defaults for :py:attr:`~.Pool.utilisation` or :py:attr:`~.Pool.allocation` raising :py:exc:`~.PropertyError`
+
+    :param target: the pool to which defaults are applied
+    :param utilisation: default utilisation in case of a :py:exc:`~.PropertyError`
+    :param allocation: default allocation in case of a :py:exc:`~.PropertyError`
+    """
+    def __init__(self, target: Pool, utilisation: float, allocation: float):
+        super().__init__(target=target)
+        self._utilisation = utilisation
+        self._allocation = allocation
+
+    @property
+    def utilisation(self) -> float:
+        """Fraction of the provided resources which is actively used"""
+        try:
+            return self.target.utilisation
+        except PropertyError:
+            return self._utilisation
+
+    @property
+    def allocation(self) -> float:
+        """Fraction of the provided resources which is assigned for usage"""
+        try:
+            return self.target.allocation
+        except PropertyError:
+            return self._allocation

--- a/cobald/interfaces/__init__.py
+++ b/cobald/interfaces/__init__.py
@@ -26,4 +26,18 @@ from ._controller import Controller
 from ._pool import Pool
 from ._proxy import PoolDecorator
 
+
+class PropertyError(AttributeError):
+    """A property cannot provide the current value of an attribute"""
+    __slots__ = ('owner', 'attribute')
+
+    def __init__(self, owner, attribute):
+        self.owner = owner
+        self.attribute = attribute
+        super().__init__()
+
+    def __str__(self):
+        return "property %r currently has no value for %r" % (self.attribute, self.owner)
+
+
 __all__ = [cls.__name__ for cls in (Pool, PoolDecorator, Controller, CompositePool)]

--- a/cobald/interfaces/__init__.py
+++ b/cobald/interfaces/__init__.py
@@ -20,6 +20,11 @@ any number of :py:class:`~.PoolDecorator` may proceed it.
         composite -> poolb
     }
 
+It is common for the properties :py:attr:`~Pool.utilisation`
+and :py:attr:`~Pool.allocation` to not have a consistent value.
+For example, a pool with no resources cannot allocate any,
+resulting in an invalid :py:attr:`~Pool.allocation` of 0/0.
+In this case, :py:exc:`~.PropertyError` should be raised.
 """
 from ._composite import CompositePool
 from ._controller import Controller
@@ -31,8 +36,10 @@ class PropertyError(AttributeError):
     """A property cannot provide the current value of an attribute"""
     __slots__ = ('owner', 'attribute')
 
-    def __init__(self, owner, attribute):
+    def __init__(self, owner, attribute: str):
+        #: the object on which the attribute was looked up
         self.owner = owner
+        #: name of the attribute on the object
         self.attribute = attribute
         super().__init__()
 
@@ -40,4 +47,4 @@ class PropertyError(AttributeError):
         return "property %r currently has no value for %r" % (self.attribute, self.owner)
 
 
-__all__ = [cls.__name__ for cls in (Pool, PoolDecorator, Controller, CompositePool)]
+__all__ = ['Pool', 'PoolDecorator', 'Controller', 'CompositePool', 'PropertyError']


### PR DESCRIPTION
Adds a new exception `PropertyError` to be thrown when a property cannot provide an attribute. This currently applies to `cobald.composite` Pools with a supply of 0. Also adds a new Decorator `cobald.decorators.default.Default` which converts any `PropertyError` to a pre-defined default value.

```
Default(allocation=1, utilisation=1, target=UniformComposite(...))
```

See also pull #16 .