### PR TITLE
Step controller

### DIFF
--- a/cobald/controller/stepwise.py
+++ b/cobald/controller/stepwise.py
@@ -1,6 +1,6 @@
 from functools import partial
 from itertools import chain
-from typing import Callable, Tuple, Optional, TypeVar, List, Set, overload
+from typing import Callable, Tuple, Optional, TypeVar, List, Set, Dict, overload
 
 import trio
 
@@ -32,7 +32,7 @@ class RangeSelector(object):
     :param rules: lower bound and its control rule
     """
     def __init__(self, base: ControlRule, *rules: Tuple[float, ControlRule]):
-        self._lookup = self._compile_lookup(base, rules)
+        self._lookup = self._compile_lookup(base, rules)  # type: Dict[Tuple[float, float], ControlRule]
 
     def get_rule(self, supply: float):
         for (low, high), rule in self._lookup.items():

--- a/cobald/controller/stepwise.py
+++ b/cobald/controller/stepwise.py
@@ -41,6 +41,8 @@ class RangeSelector(object):
 
     @staticmethod
     def _compile_lookup(base, rules):
+        if not rules:
+            return {(0, float('inf')): base}
         lookup = {}
         thresholds, _rules = zip(*sorted(rules))
         for low, high, rule in zip(

--- a/cobald/controller/stepwise.py
+++ b/cobald/controller/stepwise.py
@@ -181,7 +181,9 @@ class UnboundStepwise(object):
         """
         return Partial(Stepwise, self.base, *self.rules, *args, **kwargs)
 
-    def __call__(self, target: Pool, interval: float):
+    def __call__(self, target: Pool, interval: float = None):
+        if interval is None:
+            return Stepwise(target, self.base, *self.rules)
         return Stepwise(target, self.base, *self.rules, interval=interval)
 
 

--- a/cobald/controller/stepwise.py
+++ b/cobald/controller/stepwise.py
@@ -1,0 +1,159 @@
+from functools import partialmethod
+from itertools import chain
+from typing import Callable, Tuple, Optional
+
+import trio
+
+from ..interfaces import Pool, Controller
+from ..daemon.service import service
+
+#: Individual control rule for a pool on a given interval
+#:
+#: When a rule for a :py:class:`Stepwise` is invoked, it receives
+#: the ``pool`` to manage and the ``interval`` elapsed since the
+#: last modification.
+#: It should either *return* the new :py:attr:`~.Pool.demand`, or
+#: :py:const:`None` to indicate no change; the latter can also
+#: mean that the function does not hit a ``return`` statement.
+#:
+#: .. py:function:: \ rule(pool: Pool, interval: float) -> Optional[float]
+#:
+#: Note that a rule should *not* modify the ``pool`` directly.
+ControlRule = Callable[[Pool, float], Optional[float]]
+
+
+class RangeSelector(object):
+    """
+    Container that stores rules for the range of their supply bounds
+
+    :param base: base rule that has no lower bound
+    :param rules: lower bound and its control rule
+    """
+    def __init__(self, base: ControlRule, *rules: Tuple[float, ControlRule]):
+        self._lookup = self._compile_lookup(base, rules)
+
+    def get_rule(self, supply: float):
+        for (low, high), rule in self._lookup.items():
+            if low <= supply < high:
+                return rule
+
+    @staticmethod
+    def _compile_lookup(base, rules):
+        lookup = {}
+        thresholds, _rules = zip(*sorted(rules))
+        for low, high, rule in zip(
+            chain([0], thresholds),
+            chain(thresholds, [float('inf')]),
+            chain([base], _rules),
+        ):
+            if low == high:
+                raise ValueError('Duplicate entries for threshold %s' % low)
+            lookup[low, high] = rule
+        return lookup
+
+
+@service(flavour=trio)
+class Stepwise(Controller):
+    """
+    Controller that selects from several strategies based on supply
+
+    :see: :py:class:`UnboundStepwise` allows creating :py:class:`Stepwise` instances
+          via decorators.
+    """
+    def __init__(self, target: Pool, base: ControlRule, *rules: Tuple[float, ControlRule], interval: float = 1):
+        super().__init__(target)
+        self.interval = interval
+        self._selector = RangeSelector(base, *rules)
+
+    async def run(self):
+        target, interval = self.target, self.interval
+        while True:
+            current_rule = self._selector.get_rule(target.supply)
+            demand = current_rule(target, interval)
+            if demand is not None:
+                self.target.demand = demand
+            await trio.sleep(interval)
+
+
+class UnboundStepwise(object):
+    """
+    Decorator interface for constructing a :py:class:`Stepwise` controller
+
+    Apply this as a decorator to a :py:data:`~.ControlRule` callable to create
+    a basic controller skeleton.
+    The initial callable forms the base rule.
+    Additional rules can be added for specific :py:attr:`~.Pool.supply` thresholds
+    using :py:meth:`~.UnboundStepwise.add`.
+
+    The skeleton can be used like a regular :py:class:`~.Controller`:
+    calling it with a :py:class:`~.Pool` and update ``interval`` creates
+    a :py:class:`~.Controller` instance with the given rules for the
+    :py:class:`~.Pool`.
+
+    .. code:: python
+
+        # initial controller skeleton from base case
+        @stepwise
+        def control(pool: Pool, interval):
+            return 10
+
+        # additional rules above specific supply thresholds
+        @control.add(supply=10)
+        def quantized(pool: Pool, interval):
+            if pool.utilisation < 0.5:
+                return pool.supply - 1
+            elif pool.allocation > 0.5:
+                return pool.supply + 1
+
+        @control.add(supply=100)
+        def continuous(pool: Pool, interval):
+            if pool.utilisation < 0.5:
+                return pool.supply * 1.1
+            elif pool.allocation > 0.5:
+                return pool.supply * 0.9
+
+        # create controller from skeleton
+        pipeline = control(pool, interval=10)
+    """
+    def __init__(self, base: ControlRule):
+        self.base = base
+        self.rules = []
+        self._thresholds = set()
+
+    def add(self, rule: ControlRule = None, *, supply: float):
+        """
+        Register a new rule above a given ``supply`` threshold
+
+        Registration supports a single-argument form for use as a decorator,
+        as well as a two-argument form for direct application.
+        Use the former for ``def`` or ``class`` definitions,
+        and the later for ``lambda`` functions and existing callables.
+
+        .. code:: python
+
+            @control.add(supply=10)
+            def linear(pool, interval):
+                if pool.utilisation < 0.75:
+                    return pool.supply - interval
+                elif pool.allocation > 0.95:
+                    return pool.supply + interval
+
+            control.add(
+                lambda pool, interval: pool.supply * (1.2 if pool.allocation > 0.75 else 0.9),
+                supply=100
+            )
+        """
+        if supply in self._thresholds:
+            raise ValueError('rule for threshold %s re-defined' % supply)
+        if rule is not None:
+            self.rules.append((supply, rule))
+            self._thresholds.add(supply)
+            return rule
+        else:
+            return partialmethod(self.add, supply=supply)
+
+    def __call__(self, target: Pool, interval: float):
+        return Stepwise(target, self.base, *self.rules, interval=interval)
+
+
+stepwise = UnboundStepwise

--- a/cobald/controller/stepwise.py
+++ b/cobald/controller/stepwise.py
@@ -1,4 +1,4 @@
-from functools import partialmethod
+from functools import partial
 from itertools import chain
 from typing import Callable, Tuple, Optional, TypeVar, List, Set, overload
 
@@ -160,7 +160,7 @@ class UnboundStepwise(object):
             self._thresholds.add(supply)
             return rule
         else:
-            return partialmethod(self.add, supply=supply)
+            return partial(self.add, supply=supply)
 
     def s(self, *args, **kwargs) -> Partial[Stepwise]:
         """

--- a/cobald/interfaces/_controller.py
+++ b/cobald/interfaces/_controller.py
@@ -29,7 +29,3 @@ class Controller(metaclass=abc.ABCMeta):
             pipeline = controller(rate=10) >> pool
         """
         return Partial(cls, *args, **kwargs)
-
-    @abc.abstractmethod
-    def regulate(self, interval: float):
-        """Regulate demand for the ``pool`` in the past ``interval`` seconds"""

--- a/cobald_tests/controller/test_stepwise.py
+++ b/cobald_tests/controller/test_stepwise.py
@@ -1,0 +1,19 @@
+from types import FunctionType
+
+from cobald.controller.stepwise import Stepwise, UnboundStepwise, stepwise
+
+
+class TestStepwise:
+    def test_add(self):
+        @stepwise
+        def control(pool, interval):
+            ...
+
+        assert isinstance(control, UnboundStepwise)
+
+        @control.add(supply=20)
+        def rule(pool, interval):
+            ...
+
+        assert isinstance(control, UnboundStepwise)
+        assert isinstance(rule, FunctionType)

--- a/cobald_tests/controller/test_stepwise.py
+++ b/cobald_tests/controller/test_stepwise.py
@@ -2,6 +2,8 @@ from types import FunctionType
 
 from cobald.controller.stepwise import Stepwise, UnboundStepwise, stepwise
 
+from ..mock.pool import FullMockPool
+
 
 class TestStepwise:
     def test_add(self):
@@ -17,3 +19,22 @@ class TestStepwise:
 
         assert isinstance(control, UnboundStepwise)
         assert isinstance(rule, FunctionType)
+
+    def test_instantiate(self):
+        @stepwise
+        def control(pool, interval):
+            ...
+
+        assert isinstance(control(FullMockPool()), Stepwise)
+        assert isinstance(control.s() >> FullMockPool(), Stepwise)
+        assert isinstance(control(FullMockPool(), interval=10), Stepwise)
+        assert isinstance(control.s(interval=10) >> FullMockPool(), Stepwise)
+
+        @control.add(supply=20)
+        def rule(pool, interval):
+            ...
+
+        assert isinstance(control(FullMockPool()), Stepwise)
+        assert isinstance(control.s() >> FullMockPool(), Stepwise)
+        assert isinstance(control(FullMockPool(), interval=10), Stepwise)
+        assert isinstance(control.s(interval=10) >> FullMockPool(), Stepwise)

--- a/docs/source/api/cobald.controller.rst
+++ b/docs/source/api/cobald.controller.rst
@@ -13,5 +13,6 @@ Submodules
 
    cobald.controller.linear
    cobald.controller.relative_supply
+   cobald.controller.stepwise
    cobald.controller.switch
 

--- a/docs/source/api/cobald.controller.stepwise.rst
+++ b/docs/source/api/cobald.controller.stepwise.rst
@@ -1,0 +1,7 @@
+cobald.controller.stepwise module
+=================================
+
+.. automodule:: cobald.controller.stepwise
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Controller that allows different rules depending on current ``supply``. Rules can be aggregated using a decorator interface. Documentation included, no unit tests yet. 

```
# initial controller skeleton from base case
@stepwise
def control(pool: Pool, interval):
    return 10

# additional rules above specific supply thresholds
@control.add(supply=10)
def quantized(pool: Pool, interval):
    if pool.utilisation < 0.5:
        return pool.supply - 1
    elif pool.allocation > 0.5:
        return pool.supply + 1

@control.add(supply=100)
def continuous(pool: Pool, interval):
    if pool.utilisation < 0.5:
        return pool.supply * 1.1
    elif pool.allocation > 0.5:
        return pool.supply * 0.9

# create controller from skeleton
pipeline = control(pool, interval=10)
```