### PR TITLE
Use yaml safe_load instead of load

### DIFF
--- a/cobald/daemon/config/yaml.py
+++ b/cobald/daemon/config/yaml.py
@@ -1,11 +1,11 @@
-from yaml import load
+from yaml import safe_load
 
 from .mapping import configure_logging, Translator, ConfigurationError
 
 
 def load_configuration(path, translator=Translator()):
     with open(path) as yaml_stream:
-        config_data = load(yaml_stream)
+        config_data = safe_load(yaml_stream)
     try:
         logging_mapping = config_data.pop('logging')
     except KeyError:

--- a/docs/source/daemon/config.rst
+++ b/docs/source/daemon/config.rst
@@ -44,6 +44,9 @@ Each ``pipeline`` is constructed in order:
 the *last* element should be a :py:class:`~cobald.interface.Pool`,
 and subsequent elements recursively receive their predecessor as the ``target`` keyword.
 
+:note: To read the yaml configuration ``yaml.SafeLoader`` is used. Implications can be found in the
+       `PyYAML <https://pyyaml.org/wiki/PyYAMLDocumentation>`_ documentation
+
 Python Code Inclusion
 ---------------------
 


### PR DESCRIPTION
Calling `yaml.load` without specifiying a Loader is deprected in PyYAML 5.1. 

```
cobald/daemon/config/yaml.py:8: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

This pull request introduces `yaml.safe_load()` to load yaml configurations.