### PR TITLE
explicit access to cobald.__about__

### DIFF
--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -5,7 +5,7 @@ import sys
 import logging
 import platform
 
-import cobald
+import cobald.__about__
 
 from .logger import initialise_logging
 from .cli import CLI


### PR DESCRIPTION
This pull request fixes an issue introduced by #26. Changing ``cobald`` to a namespace package invalidated exposing ``cobald.__about__`` in ``cobald.__init__``. An explicit import is required.