### PR TITLE
Documentation for resolution of timestamp in LineProtocolFormat…

### DIFF
--- a/src/cobald/monitor/format_line.py
+++ b/src/cobald/monitor/format_line.py
@@ -44,6 +44,12 @@ class LineProtocolFormatter(Formatter):
     The ``tags`` act as a whitelist for record keys if they are an iterable.
     When a dictionary is supplied, its values act as default values if the
     key is not in a record.
+
+    The ``resolution`` allows summarising data by downsampling the timestamps
+    to the given resolution, e.g. for a ``resolution`` of ``10`` you can expect
+    timestamps 10, 20, 30, ...
+    If ``resolution`` is ``None`` the timestamp is omitted from the Line Protocol
+    and Telegraf will take care on setting the current timestamp.
     """
     def __init__(
             self,


### PR DESCRIPTION
The `LineProtocolFormatter` currently did not contain any documentation on the usage of `resolution`. This introduced misunderstanding of usage.

This pull requests adds documentation about the functioning and also defines what happens when `resolution` is `None`. This pull request fixes #36.