### PR TITLE
Don't accept None argument values in LineProtocolFormatter

### DIFF
--- a/src/cobald/monitor/format_line.py
+++ b/src/cobald/monitor/format_line.py
@@ -68,6 +68,8 @@ class LineProtocolFormatter(Formatter):
             args = {}
         assert isinstance(args, Mapping), \
             'monitor record argument must be a mapping, not %r' % type(args)
+        assert all(elem is not None for elem in args.values()), \
+            'values for arguments are not allowed to be None'
         record.asctime = self.formatTime(record, self.datefmt)
         record.message = record.getMessage() if args else record.msg
         tags = self._default_tags.copy()

--- a/src/cobald/monitor/format_line.py
+++ b/src/cobald/monitor/format_line.py
@@ -69,7 +69,7 @@ class LineProtocolFormatter(Formatter):
         assert isinstance(args, Mapping), \
             'monitor record argument must be a mapping, not %r' % type(args)
         assert all(elem is not None for elem in args.values()), \
-            'values for arguments are not allowed to be None'
+            'line protocol values must not be None'
         record.asctime = self.formatTime(record, self.datefmt)
         record.message = record.getMessage() if args else record.msg
         tags = self._default_tags.copy()


### PR DESCRIPTION
Line Protocol does not allow None values for arguments. This will result in an error. This PR therefore introduces an assertion that all values are correctly set.