### PR TITLE
YAML Constructors and Plugins

### DIFF
--- a/docs/source/custom/overview.rst
+++ b/docs/source/custom/overview.rst
@@ -4,6 +4,7 @@ Custom Controllers, Pools and Extensions
 
 The :py:mod:`cobald.daemon` is capable of loading any modules and code importable
 by its Python interpreter.
+In addition, plugins can be registered for fast access in configuration files.
 Extensions are integrated as classes that satisfy the :py:class:`~.Controller`,
 :py:class:`~.Pool` or :py:class:`~.Decorator` interfaces.
 Internally, extensions can be organized and implemented as required.

--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -6,7 +6,7 @@ Extensions for :py:mod:`cobald` are regular Python code accessible to the interp
 For specific problems, extensions can be defined directly in a Python configuration file.
 General purpose and reusable code should be made available as a Python package.
 This ensures proper installation and dependency management,
-and allows quick access in YAML configuration files.
+and allows quick access from YAML configuration files.
 
 Configuration Files
 ===================
@@ -116,7 +116,7 @@ can be made available as ``MyExtension`` in this way:
     )
 
 This allows using the extension with YAML tag syntax as ``!MyExtension``.
-Extension are treated as callables and, depending on how their node is defined,
+Extensions are treated as callables and, depending on how their node is defined,
 receive keyword arguments (mapping node),
 positional arguments (sequence node),
 or no arguments (scalar node).

--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -5,7 +5,8 @@ Using and Distributing Extensions
 Extensions for :py:mod:`cobald` are regular Python code accessible to the interpreter.
 For specific problems, extensions can be defined directly in a Python configuration file.
 General purpose and reusable code should be made available as a Python package.
-This ensures proper installation and dependency management.
+This ensures proper installation and dependency management,
+and allows quick access in YAML configuration files.
 
 Configuration Files
 ===================
@@ -93,7 +94,40 @@ keywords should mention ``cobald`` for findability.
         ...
     )
 
-There are currently no ``entry_points`` used by :py:mod:`cobald`.
+Configuration Plugins
+*********************
+
+Packages can declare callables as plugins for the YAML configuration format.
+Plugins are added as ``entry_points`` of the ``cobald.config.yaml_constructors`` group,
+with a name to be used in configurations.
+For example, a plugin class ``ExtensionClass`` defined in ``mypackage.mymodule``
+can be made available as ``MyExtension`` in this way:
+
+.. code:: python3
+
+    setup(
+        ...,
+        entry_points={
+            'cobald.config.yaml_constructors': [
+                'MyExtension = mypackage.mymodule:ExtensionClass',
+            ],
+        },
+        ...
+    )
+
+This allows using the extension with YAML tag syntax as ``!MyExtension``.
+Extension are treated as callables and, depending on how their node is defined,
+receive keyword arguments (mapping node),
+positional arguments (sequence node),
+or no arguments (scalar node).
+
+.. code:: YAML
+
+    # resolves to ExtensionClass(foo=2, bar="Hello World!")
+    - !MyExtension
+      foo: 2
+      bar: "Hello World!"
+
 
 The ``cobald`` Namespace
 ************************

--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -115,11 +115,13 @@ can be made available as ``MyExtension`` in this way:
         ...
     )
 
-This allows using the extension with YAML tag syntax as ``!MyExtension``.
-Extensions are treated as callables and, depending on how their node is defined,
-receive keyword arguments (mapping node),
-positional arguments (sequence node),
-or no arguments (scalar node).
+This allows using the extension as elements with YAML tag syntax,
+such as ``!MyExtension``.
+Extensions are treated as callables and
+receive arguments depending on the type of their element:
+mappings are used as keyword arguments,
+and
+sequences are used as positional arguments.
 
 .. code:: YAML
 
@@ -127,6 +129,10 @@ or no arguments (scalar node).
     - !MyExtension
       foo: 2
       bar: "Hello World!"
+    # resolves to ExtensionClass(2, "Hello World!")
+    - !MyExtension
+      - 2
+      - "Hello World!"
 
 
 The ``cobald`` Namespace

--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -97,7 +97,8 @@ keywords should mention ``cobald`` for findability.
 Configuration Plugins
 *********************
 
-Packages can declare callables as plugins for the YAML configuration format.
+In order to use extensions in YAML configuration files,
+packages can declare any callable as a plugin.
 Plugins are added as ``entry_points`` of the ``cobald.config.yaml_constructors`` group,
 with a name to be used in configurations.
 For example, a plugin class ``ExtensionClass`` defined in ``mypackage.mymodule``

--- a/docs/source/daemon/config.rst
+++ b/docs/source/daemon/config.rst
@@ -16,15 +16,53 @@ The file extension determines the type of configuration interface to use -
     $ python3 -m cobald.daemon /etc/cobald/config.py
 
 The YAML Interface
-------------------
+==================
 
 The top level of a YAML configuration file is a mapping with two sections:
 the ``pipeline`` section setting up a pool control pipeline,
 and the ``logging`` section setting up the logging facilities.
-The ``logging`` section is optional and follows the standard `configuration dictionary schema`_.
+The ``logging`` section is optional and follows the standard
+`configuration dictionary schema`_.
 
-The ``pipeline`` section contains a sequence of :py:class:`~cobald.interface.Controller`,
-:py:class:`~cobald.interface.Decorator` and :py:class:`~cobald.interface.Pool`\ s.
+The ``pipeline`` section must contain a sequence of
+:py:class:`~cobald.interface.Controller`\ s,
+:py:class:`~cobald.interface.Decorator`\ s
+and :py:class:`~cobald.interface.Pool`\ s.
+Each ``pipeline`` is constructed in reverse order:
+the *last* element should be a :py:class:`~cobald.interface.Pool`
+and is constructed first,
+then recursively passed to its predecessor to for construction.
+
+.. code:: yaml
+
+    # pool becomes the target of the controller
+    pipeline:
+        - !LinearController
+          low_utilisation: 0.9
+          high_utilisation: 1.1
+        - !CpuPool
+          interval: 1
+
+Object References
+*****************
+
+YAML configurations support ``!!`` tag and ``!`` constructor syntax.
+These allow to use arbitrary Python objects and registered plugins, respectively.
+Both support keyword and positional arguments.
+
+.. code:: yaml
+
+    # generic python tag for arbitrary objects
+    !!python/object:cobald.controller.linear.LinearController {low_utilisation: 0.9}
+    # constructor tag for registered plugin
+    !LinearController
+    low_utilisation: 0.9
+
+.. versionadded:: 0.9.3
+
+.. seealso:: The `PyYAML`_ documentation on "YAML tags and Python types".
+
+A legacy format using explicit type references is available, but discouraged.
 This uses an invocation mechanism that can use arbitrary callables to construct objects:
 each mapping with a ``__type__`` key is invoked with its items as keyword arguments,
 and the optional ``__args__`` as positional arguments.
@@ -40,18 +78,19 @@ and the optional ``__args__`` as positional arguments.
           keyword1: one
           keyword2: two
 
-Each ``pipeline`` is constructed in order:
-the *last* element should be a :py:class:`~cobald.interface.Pool`,
-and subsequent elements recursively receive their predecessor as the ``target`` keyword.
+.. deprecated:: 0.9.3
+    Use YAML tags and constructors instead.
 
-:note: To read the yaml configuration ``yaml.SafeLoader`` is used. Implications can be found in the
-       `PyYAML <https://pyyaml.org/wiki/PyYAMLDocumentation>`_ documentation
+:note: To read the yaml configuration ``yaml.SafeLoader`` is used. See the
+       `PyYAML`_ documentation for details.
 
 Python Code Inclusion
----------------------
+=====================
 
 Python configuration files are loaded like regular modules.
 This allows to define arbitrary types and functions, and directly chain components or configure logging.
 At least one :py:class:`~.cobald.daemon.service.service` should be instantiated.
 
 .. _`configuration dictionary schema`: https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
+
+.. _`PyYAML`: https://pyyaml.org/wiki/PyYAMLDocumentation

--- a/docs/source/daemon/config.rst
+++ b/docs/source/daemon/config.rst
@@ -31,7 +31,7 @@ and :py:class:`~cobald.interface.Pool`\ s.
 Each ``pipeline`` is constructed in reverse order:
 the *last* element should be a :py:class:`~cobald.interface.Pool`
 and is constructed first,
-then recursively passed to its predecessor to for construction.
+then recursively passed to its predecessor for construction.
 
 .. code:: yaml
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,18 @@ if __name__ == '__main__':
             'console_scripts': [
                 'cobald = cobald.daemon.core.main:cli_run',
             ],
+            'cobald.config.yaml_constructors': [
+                '%s = %s:%s' % (name, module, name)
+                for name, module in
+                (
+                    ('LinearController', 'cobald.controller.linear'),
+                    ('RelativeSupplyController', 'cobald.controller.relative_supply'),
+                    ('Buffer', 'cobald.decorator.buffer'),
+                    ('Limiter', 'cobald.decorator.limiter'),
+                    ('Logger', 'cobald.decorator.logger'),
+                    ('Standardiser', 'cobald.decorator.standardiser'),
+                )
+            ],
         },
         # >>> Dependencies
         install_requires=[

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -38,12 +38,12 @@ def yaml_constructor(factory):
     """
     Convert a factory function/class to a YAML constructor
 
-    :param factory:
+    :param factory: the factory function/class
     :return: factory constructor
 
     Applying this helper to a factory allows it to be used as a YAML constructor,
     without it knowing about YAML itself.
-    It properly construct nodes and converts
+    It properly constructs nodes and converts
     mapping nodes to ``factory(**node)``,
     sequence nodes to ``factory(*node)``, and
     scalar nodes to ``factory()``.

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -1,11 +1,20 @@
-from yaml import safe_load
+from typing import Type
+from yaml import SafeLoader, BaseLoader, nodes
 
 from .mapping import configure_logging, Translator, ConfigurationError
 
 
-def load_configuration(path, translator=Translator()):
+def load_configuration(
+        path: str,
+        loader: Type[BaseLoader] = SafeLoader,
+        translator=Translator()
+):
     with open(path) as yaml_stream:
-        config_data = safe_load(yaml_stream)
+        loader_instance = loader(yaml_stream)
+        try:
+            config_data = loader_instance.get_single_data()
+        finally:
+            loader_instance.dispose()
     try:
         logging_mapping = config_data.pop('logging')
     except KeyError:

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -57,7 +57,7 @@ def yaml_constructor(factory):
           a: 0.3
           b: 0.7
     """
-    def factory_constructor(loader: BaseLoader, node):
+    def factory_constructor(loader: BaseLoader, node: nodes.Node):
         if isinstance(node, nodes.MappingNode):
             kwargs = loader.construct_mapping(node)
             return factory(**kwargs)

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -32,3 +32,43 @@ def load_configuration(
                 what='dangling configuration keys (%s)' % ', '.join(config_data),
             )
         return translator.translate_hierarchy({'pipeline': root_pipeline})
+
+
+def yaml_constructor(factory):
+    """
+    Convert a factory function/class to a YAML constructor
+
+    :param factory:
+    :return: factory constructor
+
+    Applying this helper to a factory allows it to be used as a YAML constructor,
+    without it knowing about YAML itself.
+    It properly construct nodes and converts
+    mapping nodes to ``factory(**node)``,
+    sequence nodes to ``factory(*node)``, and
+    scalar nodes to ``factory()``.
+
+    For example, registering the constructor ``yaml_constructor(factory)`` as
+    ``!factory`` means the following YAML is converted to ``factory(a=0.3, b=0.7)``:
+
+    .. code::
+
+        - !factory
+          a: 0.3
+          b: 0.7
+    """
+    def factory_constructor(loader: BaseLoader, node):
+        if isinstance(node, nodes.MappingNode):
+            kwargs = loader.construct_mapping(node)
+            return factory(**kwargs)
+        elif isinstance(node, nodes.ScalarNode):
+            return factory()
+        elif isinstance(node, nodes.SequenceNode):
+            args = loader.construct_sequence(node)
+            return factory(*args)
+        else:
+            raise ConfigurationError(
+                'YAML constructor %r on unsupported node type %s' % (
+                    node.tag, type(node).__name__
+                ))
+    return factory_constructor


### PR DESCRIPTION
Means to use and define YAML constructors for configuration. This pull request includes:

* [x] customisation of YAML configuration loader,
* [x] helper for defining factory functions as YAML constructors,
* [x] plugin mechanism for packages to define YAML constructors,
* [x] default plugins of useable Controllers and Decorators,
* [x] documentation on using YAML constructors,
* [x] documentation on defining YAML constructor plugins.

This pull request closes #41.