### PR TITLE
Cobald allows additional content in configurations

### DIFF
--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -1,0 +1,50 @@
+from tempfile import NamedTemporaryFile
+
+from cobald.daemon.core.config import load, COBalDLoader, yaml_constructor
+
+from ...mock.pool import MockPool
+
+
+# register test pool as safe for YAML configurations
+COBalDLoader.add_constructor(
+    tag='!MockPool',
+    constructor=yaml_constructor(MockPool)
+)
+
+
+class TestYamlConfig:
+    def test_load(self):
+        """Load a valid YAML config"""
+        with NamedTemporaryFile(suffix='.yaml') as config:
+            with open(config.name, 'w') as write_stream:
+                write_stream.write(
+                    """
+                    pipeline:
+                        - !LinearController
+                          low_utilisation: 0.9
+                          high_utilisation: 1.1
+                        - !MockPool
+                    """
+                )
+            with load(config.name):
+                assert True
+            assert True
+
+    def test_load_dangling(self):
+        """Load a YAML config with dangling content"""
+        with NamedTemporaryFile(suffix='.yaml') as config:
+            with open(config.name, 'w') as write_stream:
+                write_stream.write(
+                    """
+                    pipeline:
+                        - !LinearController
+                          low_utilisation: 0.9
+                          high_utilisation: 1.1
+                        - !MockPool
+                    random_things:
+                        foo: bar
+                    """
+                )
+            with load(config.name):
+                assert True
+            assert True

--- a/docs/source/changes/51.dangling_config.yaml
+++ b/docs/source/changes/51.dangling_config.yaml
@@ -1,0 +1,9 @@
+category: changed
+summary: "COBalD configuration files may include additional sections"
+description: |
+  When COBalD encounters unused sections in its configuration, it only emits
+  a log message. This allows adding configuration sections for plugins.
+issues:
+- 50
+pull requests:
+- 51

--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -94,6 +94,8 @@ keywords should mention ``cobald`` for findability.
         ...
     )
 
+.. _extension_config_plugins:
+
 Configuration Plugins
 *********************
 

--- a/docs/source/daemon/config.rst
+++ b/docs/source/daemon/config.rst
@@ -91,7 +91,25 @@ Python Code Inclusion
 
 Python configuration files are loaded like regular modules.
 This allows to define arbitrary types and functions, and directly chain components or configure logging.
-At least one :py:class:`~.cobald.daemon.service.service` should be instantiated.
+At least one pipeline of :py:class:`~cobald.interface.Controller`\ s,
+:py:class:`~cobald.interface.Decorator`\ s
+and :py:class:`~cobald.interface.Pool`\ s should be instantiated.
+
+.. code:: python3
+
+    from cobald.controller.linear import LinearController
+
+    from cobald_demo.cpu_pool import CpuPool
+    from cobald_demo.draw_line import DrawLineHook
+
+    pipeline = LinearController.s(
+        low_utilisation=0.9, high_allocation=1.1
+    ) >> CpuPool()
+
+As regular modules, Python configurations must explicitly import the components they use.
+In addition, everything not bound to a name will be garbage collected.
+This allows configurations to use temporary objects, e.g. reading from files or sockets,
+but means persistent objects (such as a pipeline) must be bound to a name.
 
 .. [#dangling] YAML configurations allow for additional sections to configure plugins.
                Additional sections are :ref:`logged <daemon_logging>` to the

--- a/docs/source/daemon/config.rst
+++ b/docs/source/daemon/config.rst
@@ -22,7 +22,7 @@ The top level of a YAML configuration file is a mapping with two sections:
 the ``pipeline`` section setting up a pool control pipeline,
 and the ``logging`` section setting up the logging facilities.
 The ``logging`` section is optional and follows the standard
-`configuration dictionary schema`_.
+`configuration dictionary schema`_. [#dangling]_
 
 The ``pipeline`` section must contain a sequence of
 :py:class:`~cobald.interface.Controller`\ s,
@@ -90,6 +90,10 @@ Python Code Inclusion
 Python configuration files are loaded like regular modules.
 This allows to define arbitrary types and functions, and directly chain components or configure logging.
 At least one :py:class:`~.cobald.daemon.service.service` should be instantiated.
+
+.. [#dangling] YAML configurations allow for additional sections to configure plugins.
+               Additional sections are :ref:`logged <daemon_logging>` to the
+               ``"cobald.runtime.config"`` channel.
 
 .. _`configuration dictionary schema`: https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
 

--- a/docs/source/daemon/config.rst
+++ b/docs/source/daemon/config.rst
@@ -4,7 +4,7 @@ Component Configuration
 
 Configuration of the :py:mod:`cobald.daemon` is performed at startup via one of two methods:
 a YAML file or Python code.
-While the former is more structured and easier to verify, the later allows for greater freedom.
+While the former is more structured and easier to verify, the latter allows for greater freedom.
 
 The configuration file is the only positional argument when launching the :py:mod:`cobald.daemon`.
 The file extension determines the type of configuration interface to use -
@@ -60,7 +60,12 @@ Both support keyword and positional arguments.
 
 .. versionadded:: 0.9.3
 
-.. seealso:: The `PyYAML`_ documentation on "YAML tags and Python types".
+.. note::
+
+    The YAML configuration is read using ``yaml.SafeLoader`` to avoid arbitrary code execution.
+    Objects must be marked as safe for loading,
+    either as :ref:`COBalD plugins <extension_config_plugins>`
+    or using `PyYAML`_ directly.
 
 A legacy format using explicit type references is available, but discouraged.
 This uses an invocation mechanism that can use arbitrary callables to construct objects:
@@ -80,9 +85,6 @@ and the optional ``__args__`` as positional arguments.
 
 .. deprecated:: 0.9.3
     Use YAML tags and constructors instead.
-
-:note: To read the yaml configuration ``yaml.SafeLoader`` is used. See the
-       `PyYAML`_ documentation for details.
 
 Python Code Inclusion
 =====================

--- a/docs/source/daemon/logging.rst
+++ b/docs/source/daemon/logging.rst
@@ -1,3 +1,5 @@
+.. _daemon_logging:
+
 ===========================
 Standard Logging Facilities
 ===========================

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -30,7 +30,7 @@ def load_configuration(
     else:
         if config_data:
             logger = logging.getLogger("cobald.runtime.config")
-            logger.info(
+            logger.warning(
                 "COBalD core ignores configuration sections '%s'",
                 "', '".join(config_data)
             )

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -1,4 +1,6 @@
 from typing import Type
+import logging
+
 from yaml import SafeLoader, BaseLoader, nodes
 
 from .mapping import configure_logging, Translator, ConfigurationError
@@ -27,9 +29,10 @@ def load_configuration(
         raise ConfigurationError(where='root', what=err)
     else:
         if config_data:
-            raise ConfigurationError(
-                where='root',
-                what='dangling configuration keys (%s)' % ', '.join(config_data),
+            logger = logging.getLogger("cobald.runtime.config")
+            logger.info(
+                "COBalD core ignores configuration sections '%s'",
+                "', '".join(config_data)
             )
         return translator.translate_hierarchy({'pipeline': root_pipeline})
 


### PR DESCRIPTION
Allow additional configuration content. This pull request includes:

* Dangling content in configuration files results in an info log, not an exception (issue #50)

See also MatterMiners/tardis#79.