### PR TITLE
make typing a requirement for python<3.5 only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
         },
         # >>> Dependencies
         install_requires=[
-            'typing',
+            'typing; python_version < "3.5"',
             'pyyaml',
             'trio>=0.4.0',
             'include',


### PR DESCRIPTION
`typing` is part of the standard library since Python 3.5.
Without this change `python setup.py test` fails with Python 3.7 (and possibly other versions >=3.5 (untested)).

See https://github.com/python/typing/issues/573 for details.