### PR TITLE
Configuration plugins

### DIFF
--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -1,5 +1,8 @@
 from tempfile import NamedTemporaryFile
 
+import pytest
+
+from cobald.daemon.config.mapping import ConfigurationError
 from cobald.daemon.core.config import load, COBalDLoader, yaml_constructor
 
 from ...mock.pool import MockPool
@@ -45,6 +48,6 @@ class TestYamlConfig:
                         foo: bar
                     """
                 )
-            with load(config.name):
-                assert True
-            assert True
+            with pytest.raises(ConfigurationError):
+                with load(config.name):
+                    assert False

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -34,7 +34,7 @@ class TestYamlConfig:
             assert True
 
     def test_load_dangling(self):
-        """Load a YAML config with dangling content"""
+        """Forbid loading a YAML config with dangling content"""
         with NamedTemporaryFile(suffix='.yaml') as config:
             with open(config.name, 'w') as write_stream:
                 write_stream.write(
@@ -46,6 +46,20 @@ class TestYamlConfig:
                         - !MockPool
                     random_things:
                         foo: bar
+                    """
+                )
+            with pytest.raises(ConfigurationError):
+                with load(config.name):
+                    assert False
+
+    def test_load_missing(self):
+        """Forbid loading a YAML config with missing content"""
+        with NamedTemporaryFile(suffix='.yaml') as config:
+            with open(config.name, 'w') as write_stream:
+                write_stream.write(
+                    """
+                    logging:
+                        version: 1.0
                     """
                 )
             with pytest.raises(ConfigurationError):

--- a/docs/source/changes/51.dangling_config.yaml
+++ b/docs/source/changes/51.dangling_config.yaml
@@ -1,9 +1,13 @@
 category: changed
 summary: "COBalD configuration files may include additional sections"
 description: |
-  When COBalD encounters unused sections in its configuration, it only emits
-  a log message. This allows adding configuration sections for plugins.
+  Packages may define Section Plugins for the COBalD YAML configuration. A plugin
+  receives the requested section of the configuration after parsing/evaluating it.
+  The COBalD daemon verifies that no unknown configuration sections are present
+  in the YAML configuration.
 issues:
 - 50
+- 56
 pull requests:
 - 51
+- 60

--- a/docs/source/changes/51.dangling_config.yaml
+++ b/docs/source/changes/51.dangling_config.yaml
@@ -9,5 +9,4 @@ issues:
 - 50
 - 56
 pull requests:
-- 51
 - 60

--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -168,12 +168,14 @@ which are passed to the plugin after parsing and tag evaluation:
 
 .. code:: YAML
 
-    # resolves to ExtensionClass(foo=2, bar="Hello World!")
+    # standard cobald pipeline
     pipeline:
-      # standard cobald pipeline
+        - !DummyPool
+    # passes [{'some_key': 'a', 'more_key': 'b'}, 'foobar', TagPlugin()]
+    # to the Plugin requesting 'my_plugin'
     my_plugin:
-      - some_map_key: a
-        more_map_key: b
+      - some_key: a
+        more_key: b
       - foobar
       - !TagPlugin
 

--- a/docs/source/daemon/config.rst
+++ b/docs/source/daemon/config.rst
@@ -15,6 +15,8 @@ The file extension determines the type of configuration interface to use -
     $ python3 -m cobald.daemon /etc/cobald/config.yaml
     $ python3 -m cobald.daemon /etc/cobald/config.py
 
+.. _yaml_configuration:
+
 The YAML Interface
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ if __name__ == '__main__':
             'pyyaml',
             'trio>=0.4.0',
             'include',
+            'entrypoints',
         ],
         extras_require={
             'docs': ["sphinx", "sphinxcontrib-tikz", "sphinx_rtd_theme"],

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ if __name__ == '__main__':
                     ('Standardiser', 'cobald.decorator.standardiser'),
                 )
             ],
+            'cobald.config.sections': [
+                'pipeline = cobald.daemon.core.config:load_pipeline'
+            ],
         },
         # >>> Dependencies
         install_requires=[

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -1,8 +1,9 @@
 import logging
 import logging.config
 import sys
+from typing import Any, Dict, TypeVar, Callable, Tuple
 
-from typing import Any, Dict, TypeVar
+from entrypoints import EntryPoint
 
 _logger = logging.getLogger(__package__)
 
@@ -96,25 +97,61 @@ class Translator(object):
             return sys.modules[absolute_name]
 
 
+class SectionPlugin:
+    __slots__ = 'section', 'digest', 'optional'
+
+    __entry_point_flags__ = {'optional'}
+
+    def __init__(self, section: str, digest: Callable[[Any], Any], optional=False):
+        self.section = section
+        self.digest = digest
+        self.optional = optional
+
+    @classmethod
+    def load(cls, entry_point: EntryPoint) -> 'SectionPlugin':
+        digest = entry_point.load()
+        flags = set(entry_point.extras or [])
+        if not flags <= cls.__entry_point_flags__:
+            raise ValueError(
+                'unrecognized config section option %r for entry pint %r' % (
+                    flags - cls.__entry_point_flags__, entry_point
+                ))
+        return cls(
+            section=entry_point.name, digest=digest,
+            **{option: option in flags for option in cls.__entry_point_flags__}
+        )
+
+
 def load_configuration(
         config_data: Dict[str, Any],
-        translator=Translator(),
-) -> Dict[str, Any]:
+        plugins: Tuple[SectionPlugin] = (),
+) -> Dict[SectionPlugin, Any]:
     try:
         logging_mapping = config_data.pop('logging')
     except KeyError:
         pass
     else:
         configure_logging(logging_mapping)
-    try:
-        root_pipeline = config_data.pop('pipeline')
-    except KeyError as err:
-        raise ConfigurationError(where='root', what=err)
-    else:
-        if config_data:
-            logger = logging.getLogger("cobald.runtime.config")
-            logger.warning(
-                "COBalD core ignores configuration sections '%s'",
-                "', '".join(config_data)
-            )
-        return translator.translate_hierarchy({'pipeline': root_pipeline})
+    # see if there is any unexpected config content
+    unmatched = config_data.keys() - {plugin.section for plugin in plugins}
+    if unmatched:
+        raise ConfigurationError(
+            where='root', what='unknown config sections %s' % ', '.join(unmatched)
+        )
+    content = {}
+    for plugin in plugins:
+        try:
+            section_data = config_data[plugin.section]
+        except KeyError:
+            if not plugin.optional:
+                raise ConfigurationError(
+                    where='root',
+                    what='missing section %r' % plugin.section
+                )
+        else:
+            # invoke the plugin and store possible output
+            # to avoid it being garbage collected
+            plugin_content = plugin.digest(section_data)
+            if plugin_content is not None:
+                content[plugin] = plugin_content
+    return content

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -1,5 +1,4 @@
 from typing import Type
-import logging
 
 from yaml import SafeLoader, BaseLoader, nodes
 

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -3,7 +3,8 @@ import logging
 
 from yaml import SafeLoader, BaseLoader, nodes
 
-from .mapping import configure_logging, Translator, ConfigurationError
+from .mapping import load_configuration as load_mapping_configuration,\
+    Translator, ConfigurationError
 
 
 def load_configuration(
@@ -17,24 +18,7 @@ def load_configuration(
             config_data = loader_instance.get_single_data()
         finally:
             loader_instance.dispose()
-    try:
-        logging_mapping = config_data.pop('logging')
-    except KeyError:
-        pass
-    else:
-        configure_logging(logging_mapping)
-    try:
-        root_pipeline = config_data.pop('pipeline')
-    except KeyError as err:
-        raise ConfigurationError(where='root', what=err)
-    else:
-        if config_data:
-            logger = logging.getLogger("cobald.runtime.config")
-            logger.warning(
-                "COBalD core ignores configuration sections '%s'",
-                "', '".join(config_data)
-            )
-        return translator.translate_hierarchy({'pipeline': root_pipeline})
+    return load_mapping_configuration(config_data, translator)
 
 
 def yaml_constructor(factory):

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -1,15 +1,15 @@
-from typing import Type
+from typing import Type, Tuple
 
 from yaml import SafeLoader, BaseLoader, nodes
 
 from .mapping import load_configuration as load_mapping_configuration,\
-    Translator, ConfigurationError
+    ConfigurationError, SectionPlugin
 
 
 def load_configuration(
         path: str,
         loader: Type[BaseLoader] = SafeLoader,
-        translator=Translator()
+        plugins: Tuple[SectionPlugin] = (),
 ):
     with open(path) as yaml_stream:
         loader_instance = loader(yaml_stream)
@@ -17,7 +17,10 @@ def load_configuration(
             config_data = loader_instance.get_single_data()
         finally:
             loader_instance.dispose()
-    return load_mapping_configuration(config_data, translator)
+    return load_mapping_configuration(
+        config_data=config_data,
+        plugins=plugins
+    )
 
 
 def yaml_constructor(factory):

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -90,7 +90,7 @@ def load(config_path: str):
     yield
 
 
-def load_pipeline(content):
+def load_pipeline(content: list):
     """
     Load a cobald pipeline of Controller >> ... >> Pool from a configuration section
 

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from typing import Type
 
 from yaml import SafeLoader, BaseLoader
-from entrypoints import get_group_all as get_entrypoints, EntryPoint
+from entrypoints import get_group_all as get_entrypoints
 
 from ..config.yaml import load_configuration as load_yaml_configuration,\
     yaml_constructor

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Type
 
 from yaml import SafeLoader, BaseLoader
+from entrypoints import get_group_all as get_entrypoints, EntryPoint
 
 from ..config.yaml import load_configuration as load_yaml_configuration,\
     yaml_constructor
@@ -23,9 +24,13 @@ def add_constructor_plugins(
 
     :param loader: the PyYAML loader which uses the plugins
     :param entry_point_group: entry point group to search
+
+    .. note::
+
+        This directly modifies the ``loader`` by
+        calling :py:meth:`~.BaseLoader.add_constructor`.
     """
-    from pkg_resources import iter_entry_points
-    for entry in iter_entry_points(entry_point_group):
+    for entry in get_entrypoints(entry_point_group):
         if entry.name[0] == '!':
             raise RuntimeError(
                 "plugin name %r in entry point group %r may not start with '!'" % (


### PR DESCRIPTION
Adds plugin support for configuration sections. This pull request includes:

* [x] generalisation/cleanup of configuration loading,
* [x] packages may register plugins to parse configuration sections,
* [x] dangling *but unregistered* config sections are an error,
* [x] improved documentation for YAML plugins.

Closes #56. Partially replaces #51 and #50.