### PR TITLE
Mandatory Black code formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ before_script:
   - export PYTEST_ADDOPTS=-v
 script:
   - python -m flake8 -v src/ cobald_tests/
-  - python -m black  --target-version py36 --check src/ cobald_tests/
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION != 'pypy3'* ]]; then
+      python -m black  --target-version py36 --check src/ cobald_tests/
+    fi
   - coverage run setup.py test
 after_success:
   - coverage report && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 dist: xenial
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
-  - "pypy3.5"
+  - "pypy3"
 os:
   - linux
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - export PYTEST_ADDOPTS=-v
 script:
   - python -m flake8 -v src/ cobald_tests/
+  - python -m black  --target-version py36 --check src/ cobald_tests/
   - coverage run setup.py test
 after_success:
   - coverage report && codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,6 @@ the more likely and faster we can include your contribution.
     Include references to all related issues and pull requests.
 * Stand by while we review and inspect your contribution
   * A contribution MUST pass the continuous integration inspection.
-    This runs ``pytest`` and ``flake8`` on the code and unit tests.
+    This runs ``pytest``, ``black`` and ``flake8`` on the code and unit tests.
   * A contribution MUST include unit tests if it adds new features.
     It SHOULD NOT decrease the unit test coverage.

--- a/cobald_tests/controller/test_linear.py
+++ b/cobald_tests/controller/test_linear.py
@@ -17,13 +17,13 @@ class TestLinearController(object):
 
         expected_demand = 0
         for _ in range(2):
-            assert(pool.demand == expected_demand)
+            assert pool.demand == expected_demand
             controller.regulate(1)
             expected_demand += 1
 
         pool.utilisation = 0.0
         for _ in range(2):
-            assert (pool.demand == expected_demand)
+            assert pool.demand == expected_demand
             controller.regulate(1)
             expected_demand -= 1
 
@@ -34,27 +34,27 @@ class TestLinearController(object):
         old_demand = pool.demand = 1
         pool.utilisation = pool.allocation = 1.0
         controller.regulate(1)
-        assert(pool.demand - old_demand == 1)
+        assert pool.demand - old_demand == 1
 
         old_demand = pool.demand = 1
         pool.utilisation = pool.allocation = 0.0
         controller.regulate(1)
-        assert(pool.demand - old_demand == -1)
+        assert pool.demand - old_demand == -1
 
         old_demand = pool.demand = 1
         pool.utilisation = pool.allocation = controller.low_utilisation
         controller.regulate(1)
-        assert(pool.demand - old_demand == 0)
+        assert pool.demand - old_demand == 0
 
         old_demand = pool.demand = 1
-        pool.utilisation = pool.allocation = controller.low_utilisation - .01
+        pool.utilisation = pool.allocation = controller.low_utilisation - 0.01
         controller.regulate(1)
-        assert (pool.demand - old_demand == -1)
+        assert pool.demand - old_demand == -1
 
         old_demand = pool.demand = 1
-        pool.utilisation = pool.allocation = controller.low_utilisation + .01
+        pool.utilisation = pool.allocation = controller.low_utilisation + 0.01
         controller.regulate(1)
-        assert(pool.demand - old_demand == 1)
+        assert pool.demand - old_demand == 1
 
     def test_allocation(self):
         pool = MockPool()
@@ -63,34 +63,34 @@ class TestLinearController(object):
         old_demand = pool.demand = 1
         pool.allocation = pool.utilisation = 1.0
         controller.regulate(1)
-        assert(pool.demand - old_demand == 1)
+        assert pool.demand - old_demand == 1
 
         old_demand = pool.demand = 1
         pool.allocation = pool.utilisation = 0.0
         controller.regulate(1)
-        assert(pool.demand - old_demand == -1)
+        assert pool.demand - old_demand == -1
 
         old_demand = pool.demand = 1
         pool.allocation = pool.utilisation = controller.high_allocation
         controller.regulate(1)
-        assert(pool.demand - old_demand == 0)
+        assert pool.demand - old_demand == 0
 
         old_demand = pool.demand = 1
         pool.allocation = pool.utilisation = controller.high_allocation + 0.01
         controller.regulate(1)
-        assert (pool.demand - old_demand == 1)
+        assert pool.demand - old_demand == 1
 
         old_demand = pool.demand = 1
         pool.allocation = pool.utilisation = controller.high_allocation - 0.01
         controller.regulate(1)
-        assert (pool.demand - old_demand == -1)
+        assert pool.demand - old_demand == -1
 
     def test_low_high(self):
         pool = MockPool()
         with pytest.raises(AssertionError):
             LinearController(target=pool, low_utilisation=1, high_allocation=0)
-        assert(LinearController(target=pool, low_utilisation=.5, high_allocation=.5))
-        assert(LinearController(target=pool, low_utilisation=.1, high_allocation=.9))
+        assert LinearController(target=pool, low_utilisation=0.5, high_allocation=0.5)
+        assert LinearController(target=pool, low_utilisation=0.1, high_allocation=0.9)
 
     def test_rate(self):
         pool = MockPool()

--- a/cobald_tests/controller/test_relative_supply.py
+++ b/cobald_tests/controller/test_relative_supply.py
@@ -8,12 +8,12 @@ class TestRelativeSupplyController(object):
     def test_low_scale(self):
         pool = MockPool()
         with pytest.raises(Exception):
-            RelativeSupplyController(pool, low_scale=.9, high_scale=1.0)
+            RelativeSupplyController(pool, low_scale=0.9, high_scale=1.0)
 
     def test_high_scale(self):
         pool = MockPool()
         with pytest.raises(Exception):
-            RelativeSupplyController(pool, low_scale=.5, high_scale=.9)
+            RelativeSupplyController(pool, low_scale=0.5, high_scale=0.9)
 
     def test_both_scales(self):
         pool = MockPool()
@@ -27,19 +27,19 @@ class TestRelativeSupplyController(object):
         expected_demand = 0
         for _ in range(5):
             relative_supply_controller.regulate(1)
-            assert (pool.demand == expected_demand)
+            assert pool.demand == expected_demand
         pool.demand = 1
         for _ in range(5):
             expected_demand = pool.supply * relative_supply_controller.high_scale
             relative_supply_controller.regulate(1)
-            assert (pool.demand == expected_demand)
-        pool.utilisation = pool.allocation = .1
+            assert pool.demand == expected_demand
+        pool.utilisation = pool.allocation = 0.1
         for _ in range(5):
             expected_demand = pool.supply * relative_supply_controller.low_scale
             relative_supply_controller.regulate(1)
-            assert (pool.demand == expected_demand)
-        pool.utilisation = pool.allocation = .5
+            assert pool.demand == expected_demand
+        pool.utilisation = pool.allocation = 0.5
         expected_demand = pool.supply
         for _ in range(5):
             relative_supply_controller.regulate(1)
-            assert (pool.demand == expected_demand)
+            assert pool.demand == expected_demand

--- a/cobald_tests/controller/test_switch.py
+++ b/cobald_tests/controller/test_switch.py
@@ -15,8 +15,8 @@ class TestSwitchController(object):
         for _ in range(5):
             switch_controller.regulate(1)
             expected_demand += 1
-            assert(pool.demand == expected_demand)
+            assert pool.demand == expected_demand
         for _ in range(5):
-            assert(pool.demand == expected_demand)
+            assert pool.demand == expected_demand
             switch_controller.regulate(1)
             expected_demand += 2

--- a/cobald_tests/daemon/config/test_mapping.py
+++ b/cobald_tests/daemon/config/test_mapping.py
@@ -9,19 +9,20 @@ from cobald.daemon.config.mapping import Translator, ConfigurationError
 
 def fqdn(obj):
     """Assign an fully qualified name to an object"""
-    obj.fqdn = obj.__module__ + '.' + obj.__qualname__
+    obj.fqdn = obj.__module__ + "." + obj.__qualname__
     return obj
 
 
 @fqdn
 class Construct(object):
     """Type that stores its parameters on construction"""
+
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
 
     def __repr__(self):
-        return '%s(*%r, **%r)' % (self.__class__.__name__, self.args, self.kwargs)
+        return "%s(*%r, **%r)" % (self.__class__.__name__, self.args, self.kwargs)
 
 
 @fqdn
@@ -34,7 +35,7 @@ _counts = Counter()
 
 
 def counted(key):
-    return {'__type__': count.fqdn, '__args__': [key]}
+    return {"__type__": count.fqdn, "__args__": [key]}
 
 
 class SomeError(Exception):
@@ -43,7 +44,7 @@ class SomeError(Exception):
 
 @fqdn
 def raises(exc=SomeError):
-    raise exc('this is an error')
+    raise exc("this is an error")
 
 
 class TestTranslate(object):
@@ -56,84 +57,90 @@ class TestTranslate(object):
 
     def test_construct(self):
         translator = Translator()
-        for args in ((), [5, 2E7, -2, 27], range(5)):
-            for kwargs in ({}, {'foo': 'bar', 'qux': 42},):
+        for args in ((), [5, 2e7, -2, 27], range(5)):
+            for kwargs in ({}, {"foo": "bar", "qux": 42}):
                 obj = translator.construct(
-                    {'__type__': Construct.fqdn, '__args__': args, **kwargs}
+                    {"__type__": Construct.fqdn, "__args__": args, **kwargs}
                 )
                 assert isinstance(obj, Construct)
                 assert obj.args == tuple(args)
                 assert obj.kwargs == kwargs
                 noargs_obj = translator.construct(
-                    {'__type__': Construct.fqdn, **kwargs}
+                    {"__type__": Construct.fqdn, **kwargs}
                 )
                 assert not noargs_obj.args
                 assert noargs_obj.kwargs == kwargs
                 kw_obj = translator.construct(
-                    {'__type__': Construct.fqdn, '__args__': args, **kwargs},
-                    foo=42,
+                    {"__type__": Construct.fqdn, "__args__": args, **kwargs}, foo=42
                 )
-                assert kw_obj.kwargs['foo'] == 42
+                assert kw_obj.kwargs["foo"] == 42
 
     def test_translate_primitives(self):
         translator = Translator()
         for value in (
-                'foo',
-                'lasbfasfe',
-                1, 2, 1.0, 3.5,
-                [], [1, 2, [3, 4]],
-                {}, {'foo': 'bar', 'lst': [1, 2, 3]}
+            "foo",
+            "lasbfasfe",
+            1,
+            2,
+            1.0,
+            3.5,
+            [],
+            [1, 2, [3, 4]],
+            {},
+            {"foo": "bar", "lst": [1, 2, 3]},
         ):
             assert value == translator.translate_hierarchy(value)
 
     def test_translate_construct(self):
         translator = Translator()
-        plain = translator.translate_hierarchy({'__type__': Construct.fqdn})
+        plain = translator.translate_hierarchy({"__type__": Construct.fqdn})
         assert isinstance(plain, Construct)
-        nested = translator.translate_hierarchy([0, {'__type__': Construct.fqdn}, 2])
+        nested = translator.translate_hierarchy([0, {"__type__": Construct.fqdn}, 2])
         assert isinstance(nested[1], Construct)
         stacked = translator.translate_hierarchy(
-            [0, {'__type__': Construct.fqdn, 'child': {'__type__': Construct.fqdn}}, 2]
+            [0, {"__type__": Construct.fqdn, "child": {"__type__": Construct.fqdn}}, 2]
         )
         assert isinstance(stacked[1], Construct)
-        assert isinstance(stacked[1].kwargs['child'], Construct)
+        assert isinstance(stacked[1].kwargs["child"], Construct)
 
     def test_translate_bottom_up(self):
         translator = Translator()
-        plain = translator.translate_hierarchy(counted('plain'))
+        plain = translator.translate_hierarchy(counted("plain"))
         assert plain == 1
         sequence = translator.translate_hierarchy(
-            [counted('sequence') for _ in range(5)]
+            [counted("sequence") for _ in range(5)]
         )
         assert sequence == [item for item in range(5, 0, -1)]
-        nested = translator.translate_hierarchy([
-            [counted('nested') for _ in range(2)],
-            *[counted('nested') for _ in range(2)],
-            [counted('nested') for _ in range(2)]
-        ])
+        nested = translator.translate_hierarchy(
+            [
+                [counted("nested") for _ in range(2)],
+                *[counted("nested") for _ in range(2)],
+                [counted("nested") for _ in range(2)],
+            ]
+        )
         assert nested == [[6, 5], 4, 3, [2, 1]]
 
     def test_translate_error(self):
         translator = Translator()
         with pytest.raises(ConfigurationError) as err:
             translator.translate_hierarchy(
-                {'__type__': raises.fqdn}, where='test_translate_error',
+                {"__type__": raises.fqdn}, where="test_translate_error"
             )
-        assert err.value.where == 'test_translate_error'
+        assert err.value.where == "test_translate_error"
         # make sure errors propagate up without being raised anew
         with pytest.raises(ConfigurationError) as err:
             translator.translate_hierarchy(
-                [1, {'foo': {'__type__': raises.fqdn}}], where='test_translate_error',
+                [1, {"foo": {"__type__": raises.fqdn}}], where="test_translate_error"
             )
-        assert err.value.where == 'test_translate_error[1].foo'
+        assert err.value.where == "test_translate_error[1].foo"
 
     def test_lookup_failure(self):
         translator = Translator()
         with pytest.raises(ConfigurationError):
-            translator.translate_hierarchy({
-                '__type__': 'fake_module_%s.foo.bar' % random.getrandbits(32)
-            })
+            translator.translate_hierarchy(
+                {"__type__": "fake_module_%s.foo.bar" % random.getrandbits(32)}
+            )
         with pytest.raises(ConfigurationError):
-            translator.translate_hierarchy({
-                '__type__': '%s%s' % (Construct.fqdn, random.getrandbits(32))
-            })
+            translator.translate_hierarchy(
+                {"__type__": "%s%s" % (Construct.fqdn, random.getrandbits(32))}
+            )

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -9,17 +9,14 @@ from ...mock.pool import MockPool
 
 
 # register test pool as safe for YAML configurations
-COBalDLoader.add_constructor(
-    tag='!MockPool',
-    constructor=yaml_constructor(MockPool)
-)
+COBalDLoader.add_constructor(tag="!MockPool", constructor=yaml_constructor(MockPool))
 
 
 class TestYamlConfig:
     def test_load(self):
         """Load a valid YAML config"""
-        with NamedTemporaryFile(suffix='.yaml') as config:
-            with open(config.name, 'w') as write_stream:
+        with NamedTemporaryFile(suffix=".yaml") as config:
+            with open(config.name, "w") as write_stream:
                 write_stream.write(
                     """
                     pipeline:
@@ -35,8 +32,8 @@ class TestYamlConfig:
 
     def test_load_dangling(self):
         """Forbid loading a YAML config with dangling content"""
-        with NamedTemporaryFile(suffix='.yaml') as config:
-            with open(config.name, 'w') as write_stream:
+        with NamedTemporaryFile(suffix=".yaml") as config:
+            with open(config.name, "w") as write_stream:
                 write_stream.write(
                     """
                     pipeline:
@@ -54,8 +51,8 @@ class TestYamlConfig:
 
     def test_load_missing(self):
         """Forbid loading a YAML config with missing content"""
-        with NamedTemporaryFile(suffix='.yaml') as config:
-            with open(config.name, 'w') as write_stream:
+        with NamedTemporaryFile(suffix=".yaml") as config:
+            with open(config.name, "w") as write_stream:
                 write_stream.write(
                     """
                     logging:

--- a/cobald_tests/daemon/test_service.py
+++ b/cobald_tests/daemon/test_service.py
@@ -25,7 +25,7 @@ def accept(payload: ServiceRunner, name=None):
     )
     thread.start()
     if not payload.running.wait(1):
-        raise RuntimeError('%s failed to start' % payload)
+        raise RuntimeError("%s failed to start" % payload)
     try:
         yield
     finally:
@@ -36,6 +36,7 @@ def accept(payload: ServiceRunner, name=None):
 class TestServiceRunner(object):
     def test_no_tainting(self):
         """Assert that no payloads may be scheduled before starting"""
+
         def payload():
             return
 
@@ -46,9 +47,9 @@ class TestServiceRunner(object):
 
     def test_unique_reaper(self):
         """Assert that no two runners may fetch services"""
-        with accept(ServiceRunner(accept_delay=0.1), name='outer'):
+        with accept(ServiceRunner(accept_delay=0.1), name="outer"):
             with pytest.raises(RuntimeError):
-                with accept(ServiceRunner(accept_delay=0.1), name='inner'):
+                with accept(ServiceRunner(accept_delay=0.1), name="inner"):
                     pass
 
     def test_service(self):
@@ -67,12 +68,12 @@ class TestServiceRunner(object):
                 self.done.set()
 
         a = Service()
-        with accept(runner, name='test_service'):
-            assert a.done.wait(timeout=5), 'service thread completed'
-            assert len(replies) == 1, 'pre-registered service ran'
+        with accept(runner, name="test_service"):
+            assert a.done.wait(timeout=5), "service thread completed"
+            assert len(replies) == 1, "pre-registered service ran"
             b = Service()
-            assert b.done.wait(timeout=5), 'service thread completed'
-            assert len(replies) == 2, 'post-registered service ran'
+            assert b.done.wait(timeout=5), "service thread completed"
+            assert len(replies) == 2, "post-registered service ran"
 
     def test_execute(self):
         """Test running payloads synchronously"""
@@ -85,7 +86,7 @@ class TestServiceRunner(object):
             return what
 
         runner = ServiceRunner(accept_delay=0.1)
-        with accept(runner, name='test_execute'):
+        with accept(runner, name="test_execute"):
             # do not pass in values - receive default
             assert runner.execute(sub_pingpong, flavour=threading) == default
             assert runner.execute(co_pingpong, flavour=trio) == default
@@ -111,7 +112,7 @@ class TestServiceRunner(object):
             reply_store.append(what)
 
         runner = ServiceRunner(accept_delay=0.1)
-        with accept(runner, name='test_adopt'):
+        with accept(runner, name="test_adopt"):
             # do not pass in values - receive default
             assert runner.adopt(sub_pingpong, flavour=threading) is None
             assert runner.adopt(co_pingpong, flavour=trio) is None

--- a/cobald_tests/decorator/test_logger.py
+++ b/cobald_tests/decorator/test_logger.py
@@ -20,10 +20,10 @@ _test_index = 0
 _index_lock = threading.Lock()
 
 
-def make_logger(base_name: str = 'test_logger'):
+def make_logger(base_name: str = "test_logger"):
     global _test_index
     with _index_lock:
-        log_name = base_name + '.test%d' % _test_index
+        log_name = base_name + ".test%d" % _test_index
         _test_index += 1
     logger = logging.getLogger(log_name)
     logger.propagate = False
@@ -45,9 +45,9 @@ class TestLogger(object):
 
     def test_name(self):
         pool = FullMockPool()
-        chain = Logger(target=pool, name='default')
-        assert chain.name == 'default'
+        chain = Logger(target=pool, name="default")
+        assert chain.name == "default"
         chain.name = None
         assert chain.name == pool.__class__.__name__
-        chain.name = 'final'
-        assert chain.name == 'final'
+        chain.name = "final"
+        assert chain.name == "final"

--- a/cobald_tests/interfaces/test_partial.py
+++ b/cobald_tests/interfaces/test_partial.py
@@ -28,8 +28,9 @@ class TestPartial(object):
         assert isinstance(partial_control, Partial)
         partial_decorator = MockDecorator.s()
         assert isinstance(partial_decorator, Partial)
-        pipeline = partial_control >> partial_decorator \
-            >> partial_decorator >> FullMockPool()
+        pipeline = (
+            partial_control >> partial_decorator >> partial_decorator >> FullMockPool()
+        )
         assert isinstance(pipeline, MockController)
         assert isinstance(pipeline.target, MockDecorator)
         assert isinstance(pipeline.target.target, MockDecorator)
@@ -63,8 +64,9 @@ class TestPartial(object):
         for _ in range(3):
             partial_pool = partial_pool()
             assert isinstance(partial_pool, Partial)
-        pipeline = MockController.s() >> MockDecorator.s() >> MockDecorator.s()\
-            >> partial_pool
+        pipeline = (
+            MockController.s() >> MockDecorator.s() >> MockDecorator.s() >> partial_pool
+        )
         assert isinstance(pipeline, MockController)
         assert isinstance(pipeline.target, MockDecorator)
         assert isinstance(pipeline.target.target, MockDecorator)

--- a/cobald_tests/mock/pool.py
+++ b/cobald_tests/mock/pool.py
@@ -35,6 +35,7 @@ class MockPool(Pool):
 
 class FullMockPool(Pool):
     """Pool allowing to set every attribute"""
+
     demand, supply, allocation, utilisation = 0, 0, 0, 0
 
     def __init__(self, demand=0, supply=0, allocation=0.5, utilisation=0.5):

--- a/cobald_tests/monitor/__init__.py
+++ b/cobald_tests/monitor/__init__.py
@@ -22,12 +22,21 @@ _index_lock = threading.Lock()
 
 class ExtraLogger(logging.Logger):
     def makeRecord(
-            self, name, level, fn, lno, msg, args, exc_info,
-            func=None, extra=None, sinfo=None
+        self,
+        name,
+        level,
+        fn,
+        lno,
+        msg,
+        args,
+        exc_info,
+        func=None,
+        extra=None,
+        sinfo=None,
     ):
         """Replacement for Logger.makeRecord to overwrite fields via ``extra``"""
         try:
-            created = extra and extra.pop('created')
+            created = extra and extra.pop("created")
         except KeyError:
             created = None
         rv = super().makeRecord(
@@ -43,10 +52,10 @@ class ExtraLogger(logging.Logger):
         return rv
 
 
-def make_test_logger(base_name: str = 'test_logger'):
+def make_test_logger(base_name: str = "test_logger"):
     with _index_lock:
         global _test_index
-        log_name = base_name + '.test%d' % _test_index
+        log_name = base_name + ".test%d" % _test_index
         _test_index += 1
     logger = logging.getLogger(log_name)
     logger.propagate = False

--- a/cobald_tests/monitor/test_format_json.py
+++ b/cobald_tests/monitor/test_format_json.py
@@ -9,25 +9,22 @@ from . import make_test_logger
 
 class TestFormatJson(object):
     def test_payload(self):
-        for payload in (
-                {'a': 'a'},
-                {str(i): i for i in range(20)},
-        ):
+        for payload in ({"a": "a"}, {str(i): i for i in range(20)}):
             logger, handler = make_test_logger(__name__)
             handler.formatter = JsonFormatter()
-            logger.critical('message', payload)
+            logger.critical("message", payload)
             data = json.loads(handler.content)
             assert len(data) == len(payload) + 2
-            assert data.pop('message') == 'message'
-            assert data.pop('time')
+            assert data.pop("message") == "message"
+            assert data.pop("time")
             assert data == payload
 
     def test_default_timestamp(self):
         now = time.time()
-        payload = {'a': 'a', '1': 1, '2.2': 2.2}
+        payload = {"a": "a", "1": 1, "2.2": 2.2}
         logger, handler = make_test_logger(__name__)
         handler.formatter = JsonFormatter()
-        logger.critical('message', payload, extra={'created': now})
+        logger.critical("message", payload, extra={"created": now})
         data = json.loads(handler.content)
         assert len(data) == len(payload) + 2
         # from Formatter and LogRecord
@@ -35,53 +32,53 @@ class TestFormatJson(object):
         msecs = (now - int(now)) * 1000
         default_time_string = logging.Formatter.default_msec_format % (
             time.strftime(logging.Formatter.default_time_format, ct),
-            msecs
+            msecs,
         )
-        assert data.pop('time') == default_time_string
+        assert data.pop("time") == default_time_string
 
     def test_explicit_timestamp(self):
         now = time.time()
-        payload = {'a': 'a', '1': 1, '2.2': 2.2}
+        payload = {"a": "a", "1": 1, "2.2": 2.2}
         logger, handler = make_test_logger(__name__)
-        handler.formatter = JsonFormatter(datefmt='%Y')
-        logger.critical('message', payload, extra={'created': now})
+        handler.formatter = JsonFormatter(datefmt="%Y")
+        logger.critical("message", payload, extra={"created": now})
         data = json.loads(handler.content)
         assert len(data) == len(payload) + 2
         # from Formatter and LogRecord
         ct = time.localtime(now)
-        default_time_string = time.strftime('%Y', ct)
-        assert data.pop('time') == default_time_string
+        default_time_string = time.strftime("%Y", ct)
+        assert data.pop("time") == default_time_string
 
     def test_disabled_timestamp(self):
         now = time.time()
-        payload = {'a': 'a', '1': 1, '2.2': 2.2}
+        payload = {"a": "a", "1": 1, "2.2": 2.2}
         logger, handler = make_test_logger(__name__)
-        handler.formatter = JsonFormatter(datefmt='')
-        logger.critical('message', payload, extra={'created': now})
+        handler.formatter = JsonFormatter(datefmt="")
+        logger.critical("message", payload, extra={"created": now})
         data = json.loads(handler.content)
         assert len(data) == len(payload) + 1
-        assert 'time' not in data
+        assert "time" not in data
 
     def test_payload_empty(self):
         logger, handler = make_test_logger(__name__)
         handler.formatter = JsonFormatter()
-        logger.critical('message', {})
+        logger.critical("message", {})
         data = json.loads(handler.content)
         assert len(data) == 2
 
     def test_default(self):
         logger, handler = make_test_logger(__name__)
         handler.formatter = JsonFormatter(fmt={"test": 1})
-        logger.critical('message', {'drones': 1})
+        logger.critical("message", {"drones": 1})
         data = json.loads(handler.content)
         assert data.pop("test") == 1
         handler.clear()
-        logger.critical('message', {'test': 2})
+        logger.critical("message", {"test": 2})
         data = json.loads(handler.content)
         assert data.pop("test") == 2
         assert len(data) == 2
         handler.clear()
-        logger.critical('message', {})
+        logger.critical("message", {})
         data = json.loads(handler.content)
         assert data.pop("test") == 1
         assert len(data) == 2

--- a/cobald_tests/utility/concurrent/test_meta_runner.py
+++ b/cobald_tests/utility/concurrent/test_meta_runner.py
@@ -31,25 +31,26 @@ class TestMetaRunner(object):
             await trio.sleep(0.5)
 
         for flavour, payload in (
-                (threading, subroutine),
-                (asyncio, a_coroutine),
-                (trio, t_coroutine)
+            (threading, subroutine),
+            (asyncio, a_coroutine),
+            (trio, t_coroutine),
         ):
             runner = MetaRunner()
             assert not bool(runner)
             runner.register_payload(payload, flavour=flavour)
             assert bool(runner)
-            run_in_thread(runner.run, name='test_bool_payloads %s' % flavour)
+            run_in_thread(runner.run, name="test_bool_payloads %s" % flavour)
             assert bool(runner)
             runner.stop()
 
     def test_run_subroutine(self):
         """Test executing a subroutine"""
+
         def with_return():
-            return 'expected return value'
+            return "expected return value"
 
         def with_raise():
-            raise KeyError('expected exception')
+            raise KeyError("expected exception")
 
         for flavour in (threading,):
             runner = MetaRunner()
@@ -60,26 +61,28 @@ class TestMetaRunner(object):
 
     def test_run_coroutine(self):
         """Test executing a subroutine"""
+
         async def with_return():
-            return 'expected return value'
+            return "expected return value"
 
         async def with_raise():
-            raise KeyError('expected exception')
+            raise KeyError("expected exception")
 
         for flavour in (trio, asyncio):
             runner = MetaRunner()
-            run_in_thread(runner.run, name='test_run_coroutine %s' % flavour)
+            run_in_thread(runner.run, name="test_run_coroutine %s" % flavour)
             result = runner.run_payload(with_return, flavour=flavour)
             # TODO: can we actually get the value from with_return?
-            assert result == 'expected return value'
+            assert result == "expected return value"
             with pytest.raises(KeyError):
                 runner.run_payload(with_raise, flavour=flavour)
             runner.stop()
 
     def test_return_subroutine(self):
         """Test that returning from subroutines aborts runners"""
+
         def with_return():
-            return 'unhandled return value'
+            return "unhandled return value"
 
         for flavour in (threading,):
             runner = MetaRunner()
@@ -90,8 +93,9 @@ class TestMetaRunner(object):
 
     def test_return_coroutine(self):
         """Test that returning from subroutines aborts runners"""
+
         async def with_return():
-            return 'unhandled return value'
+            return "unhandled return value"
 
         for flavour in (asyncio, trio):
             runner = MetaRunner()
@@ -102,6 +106,7 @@ class TestMetaRunner(object):
 
     def test_abort_subroutine(self):
         """Test that failing subroutines abort runners"""
+
         def abort():
             raise TerminateRunner
 
@@ -128,6 +133,7 @@ class TestMetaRunner(object):
 
     def test_abort_coroutine(self):
         """Test that failing coroutines abort runners"""
+
         async def abort():
             raise TerminateRunner
 
@@ -144,6 +150,7 @@ class TestMetaRunner(object):
             async def loop():
                 while True:
                     await flavour.sleep(0)
+
             runner = MetaRunner()
 
             runner.register_payload(noop, loop, flavour=flavour)

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         extras_require={
             'docs': ["sphinx", "sphinxcontrib-tikz", "sphinx_rtd_theme"],
             'test': TESTS_REQUIRE,
-            'contrib': ['flake8', 'flake8-bugbear'] + TESTS_REQUIRE,
+            'contrib': ['flake8', 'flake8-bugbear', 'black'] + TESTS_REQUIRE,
         },
         # metadata for package search
         license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,8 @@ if __name__ == '__main__':
             'Topic :: Office/Business :: Scheduling',
             'Topic :: System :: Distributed Computing',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
         ],
         keywords=package_about['__keywords__'],
         # unit tests

--- a/src/cobald/__about__.py
+++ b/src/cobald/__about__.py
@@ -10,12 +10,12 @@ COBalD - the Opportunistic Balancing Daemon
 This is a **draft** for a feedback based balancing system for providing
 opportunistic resources.
 """
-__title__ = 'cobald'
-__summary__ = 'COBalD - the Opportunistic Balancing Daemon'
-__url__ = 'https://github.com/MatterMiners/cobald'
+__title__ = "cobald"
+__summary__ = "COBalD - the Opportunistic Balancing Daemon"
+__url__ = "https://github.com/MatterMiners/cobald"
 
-__version__ = '0.10.0'
-__author__ = 'Eileen Kuehn, Max Fischer'
-__email__ = 'mainekuehn@gmail.com'
-__copyright__ = '2018 - 2019 %s' % __author__
-__keywords__ = 'opportunistic scheduling scheduler demand feedback-loop cobald'
+__version__ = "0.10.0"
+__author__ = "Eileen Kuehn, Max Fischer"
+__email__ = "mainekuehn@gmail.com"
+__copyright__ = "2018 - 2019 %s" % __author__
+__keywords__ = "opportunistic scheduling scheduler demand feedback-loop cobald"

--- a/src/cobald/composite/factory.py
+++ b/src/cobald/composite/factory.py
@@ -36,6 +36,7 @@ class FactoryPool(CompositePool):
     For example, if a child shuts down and does not allocate its ``supply`` further,
     it should scale its reported ``allocation`` accordingly.
     """
+
     @property
     def children(self):
         return [*self._hatchery, *self._mortuary]
@@ -58,27 +59,24 @@ class FactoryPool(CompositePool):
     def utilisation(self):
         active_children = [child for child in self.children if child.supply > 0]
         try:
-            return sum(
-                child.utilisation for child in active_children
-            ) / len(active_children)
+            return sum(child.utilisation for child in active_children) / len(
+                active_children
+            )
         except ZeroDivisionError:
-            return 1.
+            return 1.0
 
     @property
     def allocation(self):
         active_children = [child for child in self.children if child.supply > 0]
         try:
-            return sum(
-                child.allocation for child in active_children
-            ) / len(active_children)
+            return sum(child.allocation for child in active_children) / len(
+                active_children
+            )
         except ZeroDivisionError:
-            return 1.
+            return 1.0
 
     def __init__(
-            self,
-            *children: Pool,
-            factory: Callable[[], Pool],
-            interval: float = 30
+        self, *children: Pool, factory: Callable[[], Pool], interval: float = 30
     ):
         self._demand = sum(child.demand for child in children)
         #: children fulfilling our demand
@@ -119,8 +117,9 @@ class FactoryPool(CompositePool):
         while missing_demand > 0:
             new_child = self.factory()
             self._hatchery.add(new_child)
-            assert new_child.demand > 0, \
-                'factory must produce children with initial demand'
+            assert (
+                new_child.demand > 0
+            ), "factory must produce children with initial demand"
             missing_demand -= new_child.demand
         self._reap_children()
 

--- a/src/cobald/composite/uniform.py
+++ b/src/cobald/composite/uniform.py
@@ -5,6 +5,7 @@ class UniformComposite(CompositePool):
     """
     Uniform composition of several pools, with each pool weighted the same
     """
+
     children = []
 
     @property
@@ -25,20 +26,18 @@ class UniformComposite(CompositePool):
     @property
     def utilisation(self):
         try:
-            return sum(
-                child.utilisation for child in self.children
-            ) / len(self.children)
+            return sum(child.utilisation for child in self.children) / len(
+                self.children
+            )
         except ZeroDivisionError:
-            return 1.
+            return 1.0
 
     @property
     def allocation(self):
         try:
-            return sum(
-                child.allocation for child in self.children
-            ) / len(self.children)
+            return sum(child.allocation for child in self.children) / len(self.children)
         except ZeroDivisionError:
-            return 1.
+            return 1.0
 
     def __init__(self, *children: Pool):
         self._demand = sum(child.demand for child in children)

--- a/src/cobald/composite/weighted.py
+++ b/src/cobald/composite/weighted.py
@@ -5,6 +5,7 @@ class WeightedComposite(CompositePool):
     """
     Weighted composition of several pools, with each pool weighted by its supply
     """
+
     children = []
 
     @property
@@ -29,20 +30,22 @@ class WeightedComposite(CompositePool):
     @property
     def utilisation(self):
         try:
-            return sum(
-                child.utilisation * child.supply for child in self.children
-            ) / self.supply
+            return (
+                sum(child.utilisation * child.supply for child in self.children)
+                / self.supply
+            )
         except ZeroDivisionError:
-            return 1.
+            return 1.0
 
     @property
     def allocation(self):
         try:
-            return sum(
-                child.allocation * child.supply for child in self.children
-            ) / self.supply
+            return (
+                sum(child.allocation * child.supply for child in self.children)
+                / self.supply
+            )
         except ZeroDivisionError:
-            return 1.
+            return 1.0
 
     def __init__(self, *children: Pool):
         self._demand = sum(child.demand for child in children)

--- a/src/cobald/controller/linear.py
+++ b/src/cobald/controller/linear.py
@@ -16,13 +16,9 @@ class LinearController(Controller):
     :param rate: maximum change of demand in resources per second
     :param interval: interval between adjustments in seconds
     """
+
     def __init__(
-            self,
-            target: Pool,
-            low_utilisation=0.5,
-            high_allocation=0.5,
-            rate=1,
-            interval=1
+        self, target: Pool, low_utilisation=0.5, high_allocation=0.5, rate=1, interval=1
     ):
         super().__init__(target=target)
         assert rate > 0

--- a/src/cobald/controller/relative_supply.py
+++ b/src/cobald/controller/relative_supply.py
@@ -17,10 +17,15 @@ class RelativeSupplyController(Controller):
     :param high_scale: scale of ``target.supply`` when increasing resources
     :param interval: interval between adjustments in seconds
     """
+
     def __init__(
-            self, target: Pool,
-            low_utilisation=0.5, high_allocation=0.5, low_scale=0.9, high_scale=1.1,
-            interval=1,
+        self,
+        target: Pool,
+        low_utilisation=0.5,
+        high_allocation=0.5,
+        low_scale=0.9,
+        high_scale=1.1,
+        interval=1,
     ):
         super().__init__(target=target)
         self.interval = interval

--- a/src/cobald/controller/stepwise.py
+++ b/src/cobald/controller/stepwise.py
@@ -7,7 +7,7 @@ import trio
 from ..interfaces import Pool, Controller, Partial
 from ..daemon import service
 
-C = TypeVar('C', bound='Controller')
+C = TypeVar("C", bound="Controller")
 
 #: Individual control rule for a pool on a given interval
 #:
@@ -31,6 +31,7 @@ class RangeSelector(object):
     :param base: base rule that has no lower bound
     :param rules: lower bound and its control rule
     """
+
     def __init__(self, base: ControlRule, *rules: Tuple[float, ControlRule]):
         self._lookup = self._compile_lookup(base, rules)
 
@@ -42,16 +43,16 @@ class RangeSelector(object):
     @staticmethod
     def _compile_lookup(base, rules) -> Dict[Tuple[float, float], ControlRule]:
         if not rules:
-            return {(0, float('inf')): base}
+            return {(0, float("inf")): base}
         lookup = {}
         thresholds, _rules = zip(*sorted(rules))
         for low, high, rule in zip(
             chain([0], thresholds),
-            chain(thresholds, [float('inf')]),
+            chain(thresholds, [float("inf")]),
             chain([base], _rules),
         ):
             if low == high:
-                raise ValueError('Duplicate entries for threshold %s' % low)
+                raise ValueError("Duplicate entries for threshold %s" % low)
             lookup[low, high] = rule
         return lookup
 
@@ -64,12 +65,13 @@ class Stepwise(Controller):
     :see: :py:class:`UnboundStepwise` allows creating :py:class:`Stepwise` instances
           via decorators.
     """
+
     def __init__(
-            self,
-            target: Pool,
-            base: ControlRule,
-            *rules: Tuple[float, ControlRule],
-            interval: float = 1
+        self,
+        target: Pool,
+        base: ControlRule,
+        *rules: Tuple[float, ControlRule],
+        interval: float = 1,
     ):
         super().__init__(target)
         self.interval = interval
@@ -125,6 +127,7 @@ class UnboundStepwise(object):
         # create controller from skeleton
         pipeline = control(pool, interval=10)
     """
+
     def __init__(self, base: ControlRule):
         self.base = base
         self.rules = []  # type: List[Tuple[float, ControlRule]]
@@ -164,7 +167,7 @@ class UnboundStepwise(object):
             )
         """
         if supply in self._thresholds:
-            raise ValueError('rule for threshold %s re-defined' % supply)
+            raise ValueError("rule for threshold %s re-defined" % supply)
         if rule is not None:
             self.rules.append((supply, rule))
             self._thresholds.add(supply)

--- a/src/cobald/controller/switch.py
+++ b/src/cobald/controller/switch.py
@@ -21,16 +21,18 @@ class DemandSwitch(Controller):
     :param slaves: pairs of minimum demand to switch and corresponding controller
     :param interval: interval between adjustments in seconds
     """
+
     def __init__(
-            self,
-            target: Pool,
-            default: Controller,
-            *slaves: Union[float, Controller], interval=1
+        self,
+        target: Pool,
+        default: Controller,
+        *slaves: Union[float, Controller],
+        interval=1,
     ):
         super().__init__(target)
         enforce(
             len(slaves) % 2 == 0,
-            InvariantError("slaves must be paired with required demands")
+            InvariantError("slaves must be paired with required demands"),
         )
         self._default = default
         self._slaves = tuple(sorted(pairwise(slaves)))
@@ -39,12 +41,12 @@ class DemandSwitch(Controller):
                 (isinstance(demand, (int, float)) and isinstance(slave, Controller))
                 for demand, slave in self._slaves
             ),
-            InvariantError("slaves must be paired with required demands (float, int)")
+            InvariantError("slaves must be paired with required demands (float, int)"),
         )
         enforce(
             default.target in (None, target)
             and all(slave.target in (None, target) for _, slave in self._slaves),
-            InvariantError("slaves must have None or same target as switch target")
+            InvariantError("slaves must have None or same target as switch target"),
         )
         default.target = target
         for _, slave in self._slaves:

--- a/src/cobald/daemon/__init__.py
+++ b/src/cobald/daemon/__init__.py
@@ -3,4 +3,4 @@ from .runners.service import ServiceRunner, service
 #: The runner invoked on daemon startup
 runtime = ServiceRunner()
 
-__all__ = ['runtime', 'service']
+__all__ = ["runtime", "service"]

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -2,14 +2,15 @@ from typing import Type, Tuple
 
 from yaml import SafeLoader, BaseLoader, nodes
 
-from .mapping import load_configuration as load_mapping_configuration,\
-    ConfigurationError, SectionPlugin
+from .mapping import (
+    load_configuration as load_mapping_configuration,
+    ConfigurationError,
+    SectionPlugin,
+)
 
 
 def load_configuration(
-        path: str,
-        loader: Type[BaseLoader] = SafeLoader,
-        plugins: Tuple[SectionPlugin] = (),
+    path: str, loader: Type[BaseLoader] = SafeLoader, plugins: Tuple[SectionPlugin] = ()
 ):
     with open(path) as yaml_stream:
         loader_instance = loader(yaml_stream)
@@ -17,10 +18,7 @@ def load_configuration(
             config_data = loader_instance.get_single_data()
         finally:
             loader_instance.dispose()
-    return load_mapping_configuration(
-        config_data=config_data,
-        plugins=plugins
-    )
+    return load_mapping_configuration(config_data=config_data, plugins=plugins)
 
 
 def yaml_constructor(factory):
@@ -46,6 +44,7 @@ def yaml_constructor(factory):
           a: 0.3
           b: 0.7
     """
+
     def factory_constructor(loader: BaseLoader, node: nodes.Node):
         if isinstance(node, nodes.MappingNode):
             kwargs = loader.construct_mapping(node)
@@ -57,7 +56,8 @@ def yaml_constructor(factory):
             return factory(*args)
         else:
             raise ConfigurationError(
-                'YAML constructor %r on unsupported node type %s' % (
-                    node.tag, type(node).__name__
-                ))
+                "YAML constructor %r on unsupported node type %s"
+                % (node.tag, type(node).__name__)
+            )
+
     return factory_constructor

--- a/src/cobald/daemon/core/cli.py
+++ b/src/cobald/daemon/core/cli.py
@@ -1,26 +1,22 @@
 import argparse
 
-CLI = argparse.ArgumentParser(description='COBalD - the Opportunistic Balancing Daemon')
-CLI.add_argument(
-    'CONFIGURATION',
-    help='path of the configuration to use',
-    type=str,
-)
-CLI_LOG = CLI.add_argument_group('Startup Logging')
+CLI = argparse.ArgumentParser(description="COBalD - the Opportunistic Balancing Daemon")
+CLI.add_argument("CONFIGURATION", help="path of the configuration to use", type=str)
+CLI_LOG = CLI.add_argument_group("Startup Logging")
 CLI_LOG.add_argument(
-    '--log-level',
-    help='initial logging level',
-    default='INFO',
-    choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+    "--log-level",
+    help="initial logging level",
+    default="INFO",
+    choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     type=str.upper,
 )
 CLI_LOG.add_argument(
-    '--log-target',
-    help='initial logging target; stdout, stderr or a file path',
-    default='stderr',
+    "--log-target",
+    help="initial logging target; stdout, stderr or a file path",
+    default="stderr",
 )
 CLI_LOG.add_argument(
-    '--log-journal',
-    help='use short formatting suitable for journals',
-    action='store_true',
+    "--log-journal",
+    help="use short formatting suitable for journals",
+    action="store_true",
 )

--- a/src/cobald/daemon/core/logger.py
+++ b/src/cobald/daemon/core/logger.py
@@ -5,9 +5,9 @@ import logging.handlers
 
 def create_handler(target: str):
     """Create a handler for logging to ``target``"""
-    if target == 'stderr':
+    if target == "stderr":
         return logging.StreamHandler(sys.stderr)
-    elif target == 'stdout':
+    elif target == "stdout":
         return logging.StreamHandler(sys.stdout)
     else:
         return logging.handlers.WatchedFileHandler(filename=target)
@@ -25,8 +25,9 @@ def initialise_logging(level: str, target: str, short_format: bool):
     handler = create_handler(target=target)
     logging.basicConfig(
         level=log_level,
-        format='%(asctime)-15s (%(process)d) %(message)s'
-               if not short_format else '%(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-        handlers=[handler]
+        format="%(asctime)-15s (%(process)d) %(message)s"
+        if not short_format
+        else "%(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=[handler],
     )

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -17,16 +17,18 @@ def run(configuration: str, level: str, target: str, short_format: bool):
     """Run the daemon and all its services"""
     initialise_logging(level=level, target=target, short_format=short_format)
     logger = logging.getLogger(__package__)
-    logger.info('COBalD %s', cobald.__about__.__version__)
+    logger.info("COBalD %s", cobald.__about__.__version__)
     logger.info(cobald.__about__.__url__)
     logger.info(
-        '%s %s (%s)',
-        platform.python_implementation(), platform.python_version(), sys.executable
+        "%s %s (%s)",
+        platform.python_implementation(),
+        platform.python_version(),
+        sys.executable,
     )
     logger.debug(cobald.__about__.__file__)
-    logger.info('Using configuration %s', configuration)
+    logger.info("Using configuration %s", configuration)
     with load(configuration):
-        logger.info('Starting daemon services...')
+        logger.info("Starting daemon services...")
         runtime.accept()
 
 

--- a/src/cobald/daemon/debug.py
+++ b/src/cobald/daemon/debug.py
@@ -8,21 +8,21 @@ from functools import partial, singledispatch
 def pretty_ref(obj: Any) -> str:
     """Pretty object reference using ``module.path:qual.name`` format"""
     try:
-        return obj.__module__ + ':' + obj.__qualname__
+        return obj.__module__ + ":" + obj.__qualname__
     except AttributeError:
-        return pretty_ref(type(obj)) + '(...)'
+        return pretty_ref(type(obj)) + "(...)"
 
 
 @pretty_ref.register(partial)
 def pretty_partial(obj: partial) -> str:
     if not obj.args and not obj.keywords:
         return pretty_ref(obj.func)
-    return 'partial(%s%s%s)' % (
+    return "partial(%s%s%s)" % (
         pretty_ref(obj.func),
-        '' if not obj.args else ', '.join(repr(arg) for arg in obj.args),
-        '' if not obj.keywords else ', '.join(
-            '%r = %r' % (k, v) for k, v in obj.keywords.items()
-        ),
+        "" if not obj.args else ", ".join(repr(arg) for arg in obj.args),
+        ""
+        if not obj.keywords
+        else ", ".join("%r = %r" % (k, v) for k, v in obj.keywords.items()),
     )
 
 
@@ -35,6 +35,7 @@ class NameRepr(object):
     """
     Lazy pretty formatter for name of objects
     """
+
     def __init__(self, target):
         self.target = target
 

--- a/src/cobald/daemon/runners/async_tools.py
+++ b/src/cobald/daemon/runners/async_tools.py
@@ -38,4 +38,4 @@ class AsyncExecution(object):
             raise exception
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, self.payload)
+        return "%s(%s)" % (self.__class__.__name__, self.payload)

--- a/src/cobald/daemon/runners/asyncio_runner.py
+++ b/src/cobald/daemon/runners/asyncio_runner.py
@@ -7,6 +7,7 @@ from .async_tools import raise_return, AsyncExecution
 
 class AsyncioRunner(BaseRunner):
     """Runner for coroutines with :py:mod:`asyncio`"""
+
     flavour = asyncio
 
     def __init__(self):
@@ -70,7 +71,7 @@ class AsyncioRunner(BaseRunner):
     def stop(self):
         if not self.running.wait(0.2):
             return
-        self._logger.debug('runner disabled: %s', self)
+        self._logger.debug("runner disabled: %s", self)
         with self._lock:
             self.running.clear()
             for task in self._tasks:

--- a/src/cobald/daemon/runners/asyncio_watcher.py
+++ b/src/cobald/daemon/runners/asyncio_watcher.py
@@ -29,9 +29,10 @@ def asyncio_main_run(root_runner: BaseRunner):
     .. seealso:: The `issue #8 <https://github.com/MatterMiners/cobald/issues/8>`_
                  for details.
     """
-    assert threading.current_thread() == threading.main_thread(),\
-        'only main thread can accept asyncio subprocesses'
-    if sys.platform == 'win32':
+    assert (
+        threading.current_thread() == threading.main_thread()
+    ), "only main thread can accept asyncio subprocesses"
+    if sys.platform == "win32":
         event_loop = asyncio.ProactorEventLoop()
         asyncio.set_event_loop(event_loop)
     else:

--- a/src/cobald/daemon/runners/base_runner.py
+++ b/src/cobald/daemon/runners/base_runner.py
@@ -10,7 +10,7 @@ class BaseRunner(object):
 
     def __init__(self):
         self._logger = logging.getLogger(
-            'cobald.runtime.runner.%s' % NameRepr(self.flavour)
+            "cobald.runtime.runner.%s" % NameRepr(self.flavour)
         )
         self._payloads = []
         self._lock = threading.Lock()
@@ -51,19 +51,20 @@ class BaseRunner(object):
         Blocks and executes payloads until :py:meth:`stop` is called.
         It is an error for any orphaned payload to return or raise.
         """
-        self._logger.info('runner started: %s', self)
+        self._logger.info("runner started: %s", self)
         try:
             with self._lock:
-                assert not self.running.is_set() and self._stopped.is_set(),\
-                    'cannot re-run: %s' % self
+                assert not self.running.is_set() and self._stopped.is_set(), (
+                    "cannot re-run: %s" % self
+                )
                 self.running.set()
                 self._stopped.clear()
             self._run()
         except Exception:
-            self._logger.exception('runner aborted: %s', self)
+            self._logger.exception("runner aborted: %s", self)
             raise
         else:
-            self._logger.info('runner stopped: %s', self)
+            self._logger.info("runner stopped: %s", self)
         finally:
             with self._lock:
                 self.running.clear()
@@ -76,7 +77,7 @@ class BaseRunner(object):
         """Stop execution of all current and future payloads"""
         if not self.running.wait(0.2):
             return
-        self._logger.debug('runner disabled: %s', self)
+        self._logger.debug("runner disabled: %s", self)
         with self._lock:
             self.running.clear()
         self._stopped.wait()
@@ -84,7 +85,8 @@ class BaseRunner(object):
 
 class OrphanedReturn(Exception):
     """A runnable returned a value without anyone to receive it"""
+
     def __init__(self, who, value):
-        super().__init__('no caller to receive %s from %s' % (value, who))
+        super().__init__("no caller to receive %s from %s" % (value, who))
         self.who = who
         self.value = value

--- a/src/cobald/daemon/runners/guard.py
+++ b/src/cobald/daemon/runners/guard.py
@@ -13,6 +13,7 @@ def exclusive(via=threading.Lock):
 
     :note: If applied to a method, it is exclusive across all instances.
     """
+
     def make_exclusive(fnc):
         fnc_guard = via()
 
@@ -24,6 +25,8 @@ def exclusive(via=threading.Lock):
                 finally:
                     fnc_guard.release()
             else:
-                raise RuntimeError('exclusive call to %s violated')
+                raise RuntimeError("exclusive call to %s violated")
+
         return exclusive_call
+
     return make_exclusive

--- a/src/cobald/daemon/runners/meta_runner.py
+++ b/src/cobald/daemon/runners/meta_runner.py
@@ -18,10 +18,11 @@ class MetaRunner(object):
     """
     Unified interface to schedule subroutines and coroutines for concurrent execution
     """
+
     runner_types = (TrioRunner, AsyncioRunner, ThreadRunner)
 
     def __init__(self):
-        self._logger = logging.getLogger('cobald.runtime.runner.meta')
+        self._logger = logging.getLogger("cobald.runtime.runner.meta")
         self.runners = {
             runner.flavour: runner() for runner in self.runner_types
         }  # type: dict[ModuleType, BaseRunner]
@@ -36,7 +37,7 @@ class MetaRunner(object):
         """Queue one or more payload for execution after its runner is started"""
         for payload in payloads:
             self._logger.debug(
-                'registering payload %s (%s)', NameRepr(payload), NameRepr(flavour)
+                "registering payload %s (%s)", NameRepr(payload), NameRepr(flavour)
             )
             self.runners[flavour].register_payload(payload)
 
@@ -46,10 +47,10 @@ class MetaRunner(object):
 
     def run(self):
         """Run all runners, blocking until completion or error"""
-        self._logger.info('starting all runners')
+        self._logger.info("starting all runners")
         try:
             with self._lock:
-                assert not self.running.set(), 'cannot re-run: %s' % self
+                assert not self.running.set(), "cannot re-run: %s" % self
                 self.running.set()
             thread_runner = self.runners[threading]
             for runner in self.runners.values():
@@ -60,11 +61,11 @@ class MetaRunner(object):
             else:
                 thread_runner.run()
         except Exception as err:
-            self._logger.exception('runner terminated: %s', err)
+            self._logger.exception("runner terminated: %s", err)
             raise RuntimeError from err
         finally:
             self._stop_runners()
-            self._logger.info('stopped all runners')
+            self._logger.info("stopped all runners")
             self.running.clear()
 
     def stop(self):
@@ -83,29 +84,34 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     import time
     import asyncio
+
     runner = MetaRunner()
 
     async def trio_sleeper():
         for i in range(3):
-            print('trio\t', i)
+            print("trio\t", i)
             await trio.sleep(0.1)
+
     runner.register_payload(trio_sleeper, flavour=trio)
 
     async def asyncio_sleeper():
         for i in range(3):
-            print('asyncio\t', i)
+            print("asyncio\t", i)
             await asyncio.sleep(0.1)
+
     runner.register_payload(asyncio_sleeper, flavour=asyncio)
 
     def thread_sleeper():
         for i in range(3):
-            print('thread\t', i)
+            print("thread\t", i)
             time.sleep(0.1)
+
     runner.register_payload(thread_sleeper, flavour=threading)
 
     async def teardown():
         await trio.sleep(5)
-        raise SystemExit('Abort from trio runner')
+        raise SystemExit("Abort from trio runner")
+
     runner.register_payload(teardown, flavour=trio)
 
     runner.run()

--- a/src/cobald/daemon/runners/thread_runner.py
+++ b/src/cobald/daemon/runners/thread_runner.py
@@ -9,6 +9,7 @@ class CapturingThread(threading.Thread):
     """
     Daemonic threads that capture any return value or exception from their ``target``
     """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs, daemon=True)
         self._exception = None
@@ -38,6 +39,7 @@ class CapturingThread(threading.Thread):
 
 class ThreadRunner(BaseRunner):
     """Runner for subroutines with :py:mod:`threading`"""
+
     flavour = threading
 
     def __init__(self):
@@ -67,7 +69,7 @@ class ThreadRunner(BaseRunner):
             thread = CapturingThread(target=subroutine)
             thread.start()
             self._threads.add(thread)
-            self._logger.debug('booted thread %s', thread)
+            self._logger.debug("booted thread %s", thread)
         time.sleep(0)
 
     def _reap_payloads(self):
@@ -76,4 +78,4 @@ class ThreadRunner(BaseRunner):
             # CapturingThread.join will throw
             if thread.join(timeout=0):
                 self._threads.remove(thread)
-                self._logger.debug('reaped thread %s', thread)
+                self._logger.debug("reaped thread %s", thread)

--- a/src/cobald/daemon/runners/trio_runner.py
+++ b/src/cobald/daemon/runners/trio_runner.py
@@ -8,6 +8,7 @@ from .async_tools import raise_return, AsyncExecution
 
 class TrioRunner(BaseRunner):
     """Runner for coroutines with :py:mod:`trio`"""
+
     flavour = trio
 
     def __init__(self):

--- a/src/cobald/decorator/buffer.py
+++ b/src/cobald/decorator/buffer.py
@@ -16,9 +16,10 @@ class Buffer(PoolDecorator):
     Any changes made to :py:attr:`demand` are stored internally.
     Every ``window`` seconds, the final demand is applied to ``target``.
     """
+
     demand = 0.0
 
-    def __init__(self, target: Pool, window: float = 10.):
+    def __init__(self, target: Pool, window: float = 10.0):
         super().__init__(target=target)
         self.window = window
         self.demand = target.demand

--- a/src/cobald/decorator/logger.py
+++ b/src/cobald/decorator/logger.py
@@ -3,10 +3,11 @@ import logging
 from cobald.interfaces import Pool, PoolDecorator
 
 
-_DEFAULT_MESSAGE = \
-    'demand = %(value)s '\
-    '[demand=%(demand)s, supply=%(supply)s, '\
-    'utilisation=%(utilisation).2f, consumption=%(consumption).2f]'
+_DEFAULT_MESSAGE = (
+    "demand = %(value)s "
+    "[demand=%(demand)s, supply=%(supply)s, "
+    "utilisation=%(utilisation).2f, consumption=%(consumption).2f]"
+)
 
 
 class Logger(PoolDecorator):
@@ -29,6 +30,7 @@ class Logger(PoolDecorator):
     ``target``
         for the raw ``target`` pool.
     """
+
     @property
     def demand(self):
         return self.target.demand
@@ -36,15 +38,17 @@ class Logger(PoolDecorator):
     @demand.setter
     def demand(self, value):
         self._logger.log(
-            self.level, self.message,
+            self.level,
+            self.message,
             {
-                'value': value,
-                'demand': self.target.demand,
-                'supply': self.target.supply,
-                'utilisation': self.target.utilisation,
-                'consumption': self.target.allocation,
-                'target': self.target,
-            })
+                "value": value,
+                "demand": self.target.demand,
+                "supply": self.target.supply,
+                "utilisation": self.target.utilisation,
+                "consumption": self.target.allocation,
+                "target": self.target,
+            },
+        )
         self.target.demand = value
 
     @property
@@ -58,11 +62,11 @@ class Logger(PoolDecorator):
         self._logger = logging.getLogger(value)
 
     def __init__(
-            self,
-            target: Pool,
-            name: str = None,
-            message: str = _DEFAULT_MESSAGE,
-            level: int = logging.INFO
+        self,
+        target: Pool,
+        name: str = None,
+        message: str = _DEFAULT_MESSAGE,
+        level: int = logging.INFO,
     ):
         super().__init__(target=target)
         self._logger = None  # type: logging.Logger

--- a/src/cobald/decorator/standardiser.py
+++ b/src/cobald/decorator/standardiser.py
@@ -21,6 +21,7 @@ class Standardiser(PoolDecorator):
     and ``minimum`` and ``maximum`` overrule all other limits.
     It is illegal to
     """
+
     @property
     def demand(self) -> float:
         if abs(self._demand - self.target.demand) >= self.granularity:
@@ -36,16 +37,19 @@ class Standardiser(PoolDecorator):
         self.target.demand = type(value)(min(maximum, max(minimum, request)))
 
     def __init__(
-            self, target: Pool,
-            minimum: float = -inf, maximum: float = inf,
-            granularity: int = 1,
-            backlog: float = inf, surplus: float = inf,
+        self,
+        target: Pool,
+        minimum: float = -inf,
+        maximum: float = inf,
+        granularity: int = 1,
+        backlog: float = inf,
+        surplus: float = inf,
     ):
         super().__init__(target)
-        enforce(minimum <= maximum, ValueError('minimum must be smaller than maximum'))
-        enforce(surplus > 0, ValueError('allowed surplus must be positive'))
-        enforce(backlog > 0, ValueError('allowed backlog must be positive'))
-        enforce(granularity > 0, ValueError('granularity must be positive'))
+        enforce(minimum <= maximum, ValueError("minimum must be smaller than maximum"))
+        enforce(surplus > 0, ValueError("allowed surplus must be positive"))
+        enforce(backlog > 0, ValueError("allowed backlog must be positive"))
+        enforce(granularity > 0, ValueError("granularity must be positive"))
         # demand may be incrementally changed - store it internally to give
         # the impression of a smooth transition
         self._demand = target.demand

--- a/src/cobald/interfaces/__init__.py
+++ b/src/cobald/interfaces/__init__.py
@@ -29,6 +29,6 @@ from ._pool import Pool
 from ._proxy import PoolDecorator
 from ._partial import Partial
 
-__all__ = [cls.__name__ for cls in (
-    Pool, PoolDecorator, Controller, CompositePool, Partial
-)]
+__all__ = [
+    cls.__name__ for cls in (Pool, PoolDecorator, Controller, CompositePool, Partial)
+]

--- a/src/cobald/interfaces/_composite.py
+++ b/src/cobald/interfaces/_composite.py
@@ -9,6 +9,7 @@ class CompositePool(Pool):
     """
     Concatenation of multiple providers for a number of indistinguishable resources
     """
+
     @property
     @abc.abstractmethod
     def supply(self):

--- a/src/cobald/interfaces/_controller.py
+++ b/src/cobald/interfaces/_controller.py
@@ -5,7 +5,7 @@ from ._pool import Pool
 from ._partial import Partial
 
 
-C = TypeVar('C', bound='Controller')
+C = TypeVar("C", bound="Controller")
 
 
 class Controller(metaclass=abc.ABCMeta):
@@ -14,6 +14,7 @@ class Controller(metaclass=abc.ABCMeta):
 
     :param target: the resource pool for which demand is adjusted
     """
+
     def __init__(self, target: Pool):
         self.target = target
 

--- a/src/cobald/interfaces/_partial.py
+++ b/src/cobald/interfaces/_partial.py
@@ -7,11 +7,12 @@ if TYPE_CHECKING:
     from ._controller import Controller
     from ._proxy import PoolDecorator
     from ._pool import Pool
+
     Owner = Union[Controller, PoolDecorator]
-    C_co = TypeVar('C_co', bound=Owner)
+    C_co = TypeVar("C_co", bound=Owner)
 else:
     Owner = Union[object]
-    C_co = TypeVar('C_co')
+    C_co = TypeVar("C_co")
 
 
 class Partial(Generic[C_co]):
@@ -38,7 +39,7 @@ class Partial(Generic[C_co]):
            creates a temporary :py:class:`~.PartialBind`. Only binding to a
            :py:class:`~.Pool` as the last element creates a concrete binding.
     """
-    __slots__ = ('ctor', 'args', 'kwargs', 'leaf')
+    __slots__ = ("ctor", "args", "kwargs", "leaf")
 
     def __init__(self, ctor: Type[C_co], *args, __leaf__, **kwargs):
         self.ctor = ctor
@@ -49,12 +50,10 @@ class Partial(Generic[C_co]):
 
     def _check_signature(self):
         args, kwargs = self.args, self.kwargs
-        if 'target' in kwargs or (args and isinstance(args[0], _pool.Pool)):
+        if "target" in kwargs or (args and isinstance(args[0], _pool.Pool)):
             raise TypeError(
                 "%s[%s] cannot bind 'target' by calling. "
-                "Use `this >> target` instead." % (
-                    self.__class__.__name__, self.ctor
-                )
+                "Use `this >> target` instead." % (self.__class__.__name__, self.ctor)
             )
         try:
             if not self.leaf:
@@ -65,26 +64,23 @@ class Partial(Generic[C_co]):
         except TypeError as err:
             message = err.args[0]
             raise TypeError(
-                '%s[%s] %s' % (self.__class__.__name__, self.ctor, message)
+                "%s[%s] %s" % (self.__class__.__name__, self.ctor, message)
             ) from err
 
-    def __call__(self, *args, **kwargs) -> 'Partial[C_co]':
+    def __call__(self, *args, **kwargs) -> "Partial[C_co]":
         return Partial(
-            self.ctor,
-            *self.args, *args,
-            __leaf__=self.leaf,
-            **self.kwargs, **kwargs
+            self.ctor, *self.args, *args, __leaf__=self.leaf, **self.kwargs, **kwargs
         )
 
     def __construct__(self, *args, **kwargs):
         return self.ctor(*args, *self.args, **kwargs, **self.kwargs)
 
     @overload  # noqa: F811
-    def __rshift__(self, other: 'Union[Owner, Pool, PartialBind[Pool]]') -> 'C_co':
+    def __rshift__(self, other: "Union[Owner, Pool, PartialBind[Pool]]") -> "C_co":
         ...
 
     @overload  # noqa: F811
-    def __rshift__(self, other: 'Union[Partial, PartialBind]') -> 'PartialBind[C_co]':
+    def __rshift__(self, other: "Union[Partial, PartialBind]") -> "PartialBind[C_co]":
         ...
 
     def __rshift__(self, other):  # noqa: F811
@@ -98,9 +94,11 @@ class Partial(Generic[C_co]):
             return self.__construct__(other)
 
     def __repr__(self):
-        return '{self.__class__.__name__}(ctor={self.ctor.__name__}'.format(self=self)\
-               + ', args={self.args}, kwargs={self.kwargs}'.format(self=self) \
-               + ', leaf={self.leaf})'.format(self=self)
+        return (
+            "{self.__class__.__name__}(ctor={self.ctor.__name__}".format(self=self)
+            + ", args={self.args}, kwargs={self.kwargs}".format(self=self)
+            + ", leaf={self.leaf})".format(self=self)
+        )
 
 
 class PartialBind(Generic[C_co]):
@@ -111,25 +109,25 @@ class PartialBind(Generic[C_co]):
     This helper is used to invert the operator precedence of ``>>``,
     allowing the last pair to be bound first.
     """
-    __slots__ = ('parent', 'targets')
+    __slots__ = ("parent", "targets")
 
     def __init__(
-            self,
-            parent: Partial[C_co],
-            *targets: 'Union[Partial[Owner], PartialBind[Owner]]'
+        self,
+        parent: Partial[C_co],
+        *targets: "Union[Partial[Owner], PartialBind[Owner]]",
     ):
         self.parent = parent
         self.targets = targets
 
     @overload  # noqa: F811
-    def __rshift__(self, other: Partial[Owner]) -> 'PartialBind[C_co]':
+    def __rshift__(self, other: Partial[Owner]) -> "PartialBind[C_co]":
         ...
 
     @overload  # noqa: F811
-    def __rshift__(self, other: 'Pool') -> 'C_co':
+    def __rshift__(self, other: "Pool") -> "C_co":
         ...
 
-    def __rshift__(self, other: 'Union[Pool, Partial[Owner]]'):  # noqa: F811
+    def __rshift__(self, other: "Union[Pool, Partial[Owner]]"):  # noqa: F811
         if isinstance(other, _pool.Pool):
             pool = self.targets[-1] >> other
             for owner in reversed(self.targets[:-1]):

--- a/src/cobald/interfaces/_pool.py
+++ b/src/cobald/interfaces/_pool.py
@@ -4,13 +4,14 @@ from typing import TypeVar, Type
 from ._partial import Partial
 
 
-C = TypeVar('C', bound='Controller')
+C = TypeVar("C", bound="Controller")
 
 
 class Pool(metaclass=abc.ABCMeta):
     """
     Individual provider for a number of indistinguishable resources
     """
+
     @property
     @abc.abstractmethod
     def supply(self) -> float:

--- a/src/cobald/interfaces/_proxy.py
+++ b/src/cobald/interfaces/_proxy.py
@@ -5,7 +5,7 @@ from typing import TypeVar, Type
 from ._partial import Partial
 
 
-C = TypeVar('C', bound='PoolDecorator')
+C = TypeVar("C", bound="PoolDecorator")
 
 
 class PoolDecorator(Pool):
@@ -14,6 +14,7 @@ class PoolDecorator(Pool):
 
     :param target: the resource pool for which demand is adjusted
     """
+
     def __init__(self, target: Pool):
         self.target = target
 

--- a/src/cobald/monitor/format_json.py
+++ b/src/cobald/monitor/format_json.py
@@ -6,10 +6,28 @@ import json
 #: Attributes of a LogRecord.
 # See <the docs `https://docs.python.org/3/library/logging.html#logrecord-attributes`>_.
 RECORD_ATTRIBUTES = (
-    'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename', 'funcName',
-    'levelname', 'levelno', 'lineno', 'message', 'module', 'msecs',
-    'msg', 'name', 'pathname', 'process', 'processName', 'relativeCreated',
-    'stack_info', 'thread', 'threadName',
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "message",
+    "module",
+    "msecs",
+    "msg",
+    "name",
+    "pathname",
+    "process",
+    "processName",
+    "relativeCreated",
+    "stack_info",
+    "thread",
+    "threadName",
 )
 
 
@@ -26,30 +44,33 @@ class JsonFormatter(Formatter):
     However, setting it to any other value that is boolean
     false excludes the timestamp from reports.
     """
+
     def __init__(self, fmt: dict = None, datefmt: str = None):
-        super().__init__(fmt=None, datefmt=datefmt, style='%')
+        super().__init__(fmt=None, datefmt=datefmt, style="%")
         self._defaults = fmt or {}
         if not isinstance(self._defaults, Mapping):
-            raise TypeError('`fmt` must be a Mapping or None')
+            raise TypeError("`fmt` must be a Mapping or None")
         self._add_time = self.datefmt or self.datefmt is None
 
     def format(self, record: LogRecord):
         args = record.args
         if args == ({},):  # logger.info('message', {}) -> record.args == ({},)
             args = {}
-        assert isinstance(args, Mapping), \
-            'monitor record argument must be a mapping, not %r' % type(args)
+        assert isinstance(
+            args, Mapping
+        ), "monitor record argument must be a mapping, not %r" % type(args)
         data = self._defaults.copy()
         if self._add_time:
-            data['time'] = self.formatTime(record, self.datefmt)
-        data['message'] = record.getMessage() if args else record.msg
+            data["time"] = self.formatTime(record, self.datefmt)
+        data["message"] = record.getMessage() if args else record.msg
         data.update(args)
         return json.dumps(data)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import logging
+
     logger = logging.getLogger()
     logger.handlers = [logging.StreamHandler()]
-    logger.handlers[0].formatter = JsonFormatter({'latitude': 49, 'longitude': 8})
-    logger.warning('forecast', {'temperature': 298, 'humidity': 0.45})
+    logger.handlers[0].formatter = JsonFormatter({"latitude": 49, "longitude": 8})
+    logger.warning("forecast", {"temperature": 298, "humidity": 0.45})

--- a/src/cobald/monitor/format_line.py
+++ b/src/cobald/monitor/format_line.py
@@ -5,22 +5,22 @@ from typing import Dict, Set, Union, Any, TypeVar
 from .format_json import RECORD_ATTRIBUTES
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def escape_key(key: str) -> str:
     assert isinstance(key, str)
-    return key.replace(r',', r'\,').replace(r'=', r'\=').replace(r' ', r'\ ')
+    return key.replace(r",", r"\,").replace(r"=", r"\=").replace(r" ", r"\ ")
 
 
 def escape_field(field: T) -> T:
     if isinstance(field, str):
-        return '"' + field.replace("\\", r"\\").replace('"', r'\"') + '"'
+        return '"' + field.replace("\\", r"\\").replace('"', r"\"") + '"'
     return field
 
 
 def line_protocol(
-        name, tags: dict = None, fields: dict = None, timestamp: float = None
+    name, tags: dict = None, fields: dict = None, timestamp: float = None
 ) -> str:
     """
     Format a report as per InfluxDB line protocol
@@ -32,22 +32,22 @@ def line_protocol(
     """
     _escape_key = escape_key
     _escape_field = escape_field
-    output_str = name.replace(r',', r'\,').replace(r' ', r'\ ')
+    output_str = name.replace(r",", r"\,").replace(r" ", r"\ ")
     if tags:
-        output_str += ','
-        output_str += ','.join(
-            '%s=%s' % (_escape_key(key), _escape_key(value))
+        output_str += ","
+        output_str += ",".join(
+            "%s=%s" % (_escape_key(key), _escape_key(value))
             for key, value in sorted(tags.items())
         )
-    output_str += ' '
-    output_str += ','.join(
-        ('%s=%s' % (_escape_key(key), _escape_field(value))).replace("'", '"')
+    output_str += " "
+    output_str += ",".join(
+        ("%s=%s" % (_escape_key(key), _escape_field(value))).replace("'", '"')
         for key, value in sorted(fields.items())
     )
     if timestamp is not None:
         # line protocol requires nanosecond precision, python uses seconds
-        output_str += ' %d' % (timestamp * 1E9)
-    return output_str + '\n'
+        output_str += " %d" % (timestamp * 1e9)
+    return output_str + "\n"
 
 
 class LineProtocolFormatter(Formatter):
@@ -67,10 +67,11 @@ class LineProtocolFormatter(Formatter):
     If ``resolution`` is ``None`` the timestamp is omitted from the Line Protocol
     and Telegraf will take care on setting the current timestamp.
     """
+
     def __init__(
-            self,
-            tags: Union[Dict[str, Any], Set[str], None] = None,
-            resolution: float = None
+        self,
+        tags: Union[Dict[str, Any], Set[str], None] = None,
+        resolution: float = None,
     ):
         super().__init__()
         self._default_tags = tags if isinstance(tags, Mapping) else {}
@@ -82,35 +83,39 @@ class LineProtocolFormatter(Formatter):
         args = record.args
         if args == ({},):  # logger.info('message', {}) -> record.args == ({},)
             args = {}
-        assert isinstance(args, Mapping), \
-            'monitor record argument must be a mapping, not %r' % type(args)
-        assert all(elem is not None for elem in args.values()), \
-            'line protocol values must not be None'
+        assert isinstance(
+            args, Mapping
+        ), "monitor record argument must be a mapping, not %r" % type(args)
+        assert all(
+            elem is not None for elem in args.values()
+        ), "line protocol values must not be None"
         record.asctime = self.formatTime(record, self.datefmt)
         record.message = record.getMessage() if args else record.msg
         tags = self._default_tags.copy()
-        tags.update({
-            key: value
-            for key, value in args.items()
-            if key in self._tags_whitelist
-        })
+        tags.update(
+            {key: value for key, value in args.items() if key in self._tags_whitelist}
+        )
         fields = {
             key: value
             for key, value in args.items()
             if key not in self._fields_blacklist
         }
-        timestamp = record.created // self._resolution * self._resolution \
-            if self._resolution is not None else None
+        timestamp = (
+            record.created // self._resolution * self._resolution
+            if self._resolution is not None
+            else None
+        )
         return line_protocol(
             name=record.message, tags=tags, fields=fields, timestamp=timestamp
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import logging
+
     logger = logging.getLogger()
     logger.handlers = [logging.StreamHandler()]
     logger.handlers[0].formatter = LineProtocolFormatter(
-        {'latitude': 49, 'longitude': 8}
+        {"latitude": 49, "longitude": 8}
     )
-    logger.warning('forecast', {'temperature': 298, 'humidity': 0.45})
+    logger.warning("forecast", {"temperature": 298, "humidity": 0.45})

--- a/src/cobald/utility/primitives.py
+++ b/src/cobald/utility/primitives.py
@@ -1,1 +1,1 @@
-infinity = float('inf')
+infinity = float("inf")


### PR DESCRIPTION
This PR makes the [Black code formatter](https://github.com/psf/black) mandatory for ``cobald`` source. This PR includes:

* [x] mandatory runs of Black on CI tests,
* [x] extension of contribution guidelines,
* [x] reformatting of all code to satisfy Black.

As a side-effect of cleaning up CI and metadata, support for Py3.5 and Py3.4 is officially removed (see also #57).