### PR TITLE
fixed wrong method name in RelativeSupplyController

### DIFF
--- a/src/cobald/controller/relative_supply.py
+++ b/src/cobald/controller/relative_supply.py
@@ -40,7 +40,7 @@ class RelativeSupplyController(Controller):
 
     async def run(self):
         while True:
-            self.regulate_demand(self.interval)
+            self.regulate(self.interval)
             await trio.sleep(self.interval)
 
     def regulate(self, interval):


### PR DESCRIPTION
Fixes a deprecated method name.