### PR TITLE
Bugfix/optional plugin

### DIFF
--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -200,7 +200,7 @@ can request the configuration section ``my_plugin`` in this way:
 .. note::
 
     Any options for Section Plugins entry points are currently implementation details.
-    In specific, *do not* use the ``[optional]`` flag used by ``cobald`` itself.
+    In specific, *do not* use the ``[required]`` flag used by ``cobald`` itself.
 
 The ``cobald`` Namespace
 ************************

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
                 )
             ],
             'cobald.config.sections': [
-                'pipeline = cobald.daemon.core.config:load_pipeline'
+                'pipeline = cobald.daemon.core.config:load_pipeline [required]'
             ],
         },
         # >>> Dependencies

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -109,16 +109,16 @@ class Translator(object):
 
 
 class SectionPlugin(Generic[M]):
-    __slots__ = "section", "digest", "optional"
+    __slots__ = "section", "digest", "required"
 
-    __entry_point_flags__ = {"optional"}
+    __entry_point_flags__ = {"required"}
 
     def __init__(
-        self, section: str, digest: Callable[[M], Any], optional: bool = False
+        self, section: str, digest: Callable[[M], Any], required: bool = False
     ):
         self.section = section
         self.digest = digest
-        self.optional = optional
+        self.required = required
 
     @classmethod
     def load(cls, entry_point: EntryPoint) -> "SectionPlugin":
@@ -156,7 +156,7 @@ def load_configuration(
         try:
             section_data = config_data[plugin.section]
         except KeyError:
-            if not plugin.optional:
+            if plugin.required:
                 raise ConfigurationError(
                     where="root", what="missing section %r" % plugin.section
                 )


### PR DESCRIPTION
This pull request inverts the flag on config section plugins to provide a sensible default. This pull request includes:

* [x] inverted ``PluginSection.optional`` to ``PluginSection.required``,
* [x] by default, plugins are *not required* (was *not optional*),
* [x] updated documentation.

Closes #64. Improves #60.