### PR TITLE
Use generalized weights in WeightedComposites

### DIFF
--- a/cobald_tests/composite/test_weighted.py
+++ b/cobald_tests/composite/test_weighted.py
@@ -1,0 +1,86 @@
+import pytest
+
+from ..mock.pool import FullMockPool
+
+from cobald.composite.weighted import WeightedComposite
+
+
+class TestWeightedComposite(object):
+    def test_init(self):
+        pool = FullMockPool()
+        WeightedComposite(pool)
+
+        with pytest.raises(AssertionError):
+            WeightedComposite(pool, weight="ShouldFail")
+
+        for weight in ("supply", "utilisation", "allocation"):
+            WeightedComposite(pool, weight=weight)
+
+    def test_demand(self):
+        pools = [FullMockPool(), FullMockPool()]
+        pools[0].demand = 123
+        pools[1].demand = 456
+
+        composite = WeightedComposite(*pools)
+        assert composite.demand == 579
+
+        # test demand setter weighted by supply (default)
+
+        pools[0].supply = 100
+        pools[1].supply = 200
+
+        composite.demand = 300
+        assert pools[0].demand == 100
+        assert pools[1].demand == 200
+
+        # test demand setter weighted by utilisation, allocation, supply
+
+        for weight in ("utilisation", "allocation", "supply"):
+            pools = [FullMockPool(), FullMockPool()]
+            composite = WeightedComposite(*pools, weight=weight)
+            setattr(pools[0], weight, 0.25)
+            setattr(pools[1], weight, 0.75)
+
+            composite.demand = 400
+            assert pools[0].demand == 100
+            assert pools[1].demand == 300
+
+    def test_supply(self):
+        pools = [FullMockPool(), FullMockPool()]
+        composite = WeightedComposite(*pools)
+        pools[0].supply = 100
+        pools[1].supply = 200
+
+        assert composite.supply == 300
+
+    def test_utilisation(self):
+        pools = [FullMockPool(), FullMockPool()]
+        pools[0].supply = 0
+        pools[1].supply = 0
+
+        composite = WeightedComposite(*pools)
+
+        assert composite.utilisation == 1.0
+
+        pools[0].supply = 100
+        pools[1].supply = 200
+        pools[0].utilisation = 0.9
+        pools[1].utilisation = 0.6
+
+        assert composite.utilisation == 0.7
+
+    def test_allocation(self):
+        pools = [FullMockPool(), FullMockPool()]
+        pools[0].supply = 0
+        pools[1].supply = 0
+
+        composite = WeightedComposite(*pools)
+
+        assert composite.allocation == 1.0
+
+        pools[0].supply = 100
+        pools[1].supply = 200
+        pools[0].allocation = 0.9
+        pools[1].allocation = 0.6
+
+        assert composite.allocation == 0.7

--- a/src/cobald/composite/weighted.py
+++ b/src/cobald/composite/weighted.py
@@ -19,7 +19,7 @@ class WeightedComposite(CompositePool):
         child_count = len(self.children)
         for pool in self.children:
             try:
-                pool.demand = value * getattr(pool, self._weight) / self.total_weight
+                pool.demand = value * getattr(pool, self._weight) / self._total_weight
             except ZeroDivisionError:
                 pool.demand = value / child_count
 
@@ -35,7 +35,7 @@ class WeightedComposite(CompositePool):
                     child.utilisation * getattr(child, self._weight)
                     for child in self.children
                 )
-                / self.total_weight
+                / self._total_weight
             )
         except ZeroDivisionError:
             return 1.0
@@ -48,13 +48,13 @@ class WeightedComposite(CompositePool):
                     child.allocation * getattr(child, self._weight)
                     for child in self.children
                 )
-                / self.total_weight
+                / self._total_weight
             )
         except ZeroDivisionError:
             return 1.0
 
     @property
-    def total_weight(self):
+    def _total_weight(self):
         return sum(getattr(child, self._weight) for child in self.children)
 
     def __init__(self, *children: Pool, weight="supply"):


### PR DESCRIPTION
The experience of using `WeightedComposite` pools in production shows that weighting by `supply` is not always the best choice. Let's assume that `COBalD` is balancing single core and eight core drones and that single core drones have a worse utilisation than 8 core drones, but single core drones have a higher supply. So, `COBalD` prefers to start single core drones instead of better utilised 8 core drones, due to their higher supply. In this scenario weighting by `utilisation` would be more desired.

This pull request enables different weights to be used in the `WeightedComposite`. `allocation`, `utilisation` and `supply` are allowed weights.