### PR TITLE
Plugin Settings/Ordering

### DIFF
--- a/docs/source/changes/70.plugin_settings.yaml
+++ b/docs/source/changes/70.plugin_settings.yaml
@@ -1,0 +1,9 @@
+category: changed
+summary: "Section Plugin settings are now specified via decorators"
+description: |
+  Configuration section plugins may now be assigned loading constraints using the
+  decorator :py:func:`cobald.daemon.plugins.constraints`. This allows marking a plugin
+  as ``required`` (it is an error if it cannot be run), and to set ordering relations
+  to other plugins.
+pull requests:
+- 70

--- a/docs/source/custom/package.rst
+++ b/docs/source/custom/package.rst
@@ -199,8 +199,13 @@ can request the configuration section ``my_plugin`` in this way:
 
 .. note::
 
-    Any options for Section Plugins entry points are currently implementation details.
-    In specific, *do not* use the ``[required]`` flag used by ``cobald`` itself.
+    If a plugin must always be covered by configuration,
+    or should run before or after another plugin,
+    decorate it with :py:func:`cobald.daemon.plugins.constraints`.
+
+.. versionadded:: 0.12
+
+    The :py:func:`cobald.daemon.plugins.constraints` and dependency resolution.
 
 The ``cobald`` Namespace
 ************************

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
             ],
         },
         # >>> Dependencies
-        install_requires=["pyyaml", "trio>=0.4.0", "include", "entrypoints"],
+        install_requires=["pyyaml", "trio>=0.4.0", "include", "entrypoints", "toposort"],
         extras_require={
             "docs": ["sphinx", "sphinxcontrib-tikz", "sphinx_rtd_theme"],
             "test": TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,13 @@ if __name__ == "__main__":
             ],
         },
         # >>> Dependencies
-        install_requires=["pyyaml", "trio>=0.4.0", "include", "entrypoints", "toposort"],
+        install_requires=[
+            "pyyaml",
+            "trio>=0.4.0",
+            "include",
+            "entrypoints",
+            "toposort",
+        ],
         extras_require={
             "docs": ["sphinx", "sphinxcontrib-tikz", "sphinx_rtd_theme"],
             "test": TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
                 )
             ],
             "cobald.config.sections": [
-                "pipeline = cobald.daemon.core.config:load_pipeline [required]"
+                "pipeline = cobald.daemon.core.config:load_pipeline"
             ],
         },
         # >>> Dependencies

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -165,6 +165,14 @@ class SectionPlugin(Generic[M]):
             )
         return cls(section=entry_point.name, digest=digest, requirements=requirements)
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}"
+            f"(section={self.section},"
+            f" digest={self.digest},"
+            f" requirements={self.requirements})"
+        )
+
 
 def load_configuration(
     config_data: Dict[str, Any], plugins: Tuple[SectionPlugin] = ()

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -117,6 +117,7 @@ class SectionPlugin(Generic[M]):
     :param required: whether the section must be present
     :param order: index of evaluating this plugin
     """
+
     __slots__ = "section", "digest", "required", "before", "after"
 
     __entry_point_flags__ = {"required"}
@@ -153,13 +154,13 @@ class SectionPlugin(Generic[M]):
         """
         digest = entry_point.load()
         options = {"before": set(), "after": set(), "required": False}
-        for option in (entry_point.extras or []):  # type: str
+        for option in entry_point.extras or []:  # type: str
             # flags
             if option == "required":
                 options["required"] = True
             # settings
             else:
-                key, _, value = map(str.strip, option.partition('='))
+                key, _, value = map(str.strip, option.partition("="))
                 if key in ("before", "after"):
                     options[key].add(value)
                 else:
@@ -167,11 +168,7 @@ class SectionPlugin(Generic[M]):
                         f"unrecognized config section option {key}"
                         f" for SectionPlugin {entry_point.name}"
                     )
-        return cls(
-            section=entry_point.name,
-            digest=digest,
-            **options,
-        )
+        return cls(section=entry_point.name, digest=digest, **options)
 
 
 def load_configuration(

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -178,11 +178,11 @@ def load_configuration(
     config_data: Dict[str, Any], plugins: Tuple[SectionPlugin] = ()
 ) -> Dict[SectionPlugin, Any]:
     """
-    Load the configuration from a mapping
+    Load the configuration from a mapping, applying plugins to sections
 
-    :param config_data:
-    :param plugins:
-    :return:
+    :param config_data: the raw configuration without any plugins applied
+    :param plugins: all plugins that *might* apply, in order
+    :return: the output of all applied plugins
     """
     try:
         logging_mapping = config_data.pop("logging")

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -144,6 +144,12 @@ class SectionPlugin(Generic[M]):
 
         ``required``
             If present implies ``required=True``.
+
+        ``before=other``
+            This plugin must be processed before ``other``.
+
+        ``after=other``
+            This plugin must be processed after ``other``.
         """
         digest = entry_point.load()
         options = {"before": set(), "after": set(), "required": False}
@@ -171,6 +177,13 @@ class SectionPlugin(Generic[M]):
 def load_configuration(
     config_data: Dict[str, Any], plugins: Tuple[SectionPlugin] = ()
 ) -> Dict[SectionPlugin, Any]:
+    """
+    Load the configuration from a mapping
+
+    :param config_data:
+    :param plugins:
+    :return:
+    """
     try:
         logging_mapping = config_data.pop("logging")
     except KeyError:

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -1,7 +1,7 @@
 import logging
 import logging.config
 import sys
-from typing import Any, Dict, TypeVar, Callable, Tuple, Generic, Set
+from typing import Any, Dict, TypeVar, Callable, Tuple, Generic
 
 from entrypoints import EntryPoint
 

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -54,20 +54,17 @@ def load_section_plugins(entry_point_group: str) -> Tuple[SectionPlugin]:
     """
     plugins: Dict[str, SectionPlugin] = {
         plugin.section: plugin
-        for plugin in
-        map(SectionPlugin.load, get_entrypoints(entry_point_group))
+        for plugin in map(SectionPlugin.load, get_entrypoints(entry_point_group))
     }
     dependencies: Dict[str, Set[str]] = {
-        plugin.section: set(plugin.after)
-        for plugin in plugins.values()
+        plugin.section: set(plugin.after) for plugin in plugins.values()
     }
     for plugin in plugins.values():
         for before in plugin.before:
             dependencies[before].add(plugin.section)
     return tuple(
         plugins[plugin_name]
-        for plugin_name in
-        toposort_flatten(dependencies, sort=False)
+        for plugin_name in toposort_flatten(dependencies, sort=False)
         if plugin_name in plugins
     )
 

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -6,6 +6,7 @@ from yaml import SafeLoader, BaseLoader
 from entrypoints import get_group_all as get_entrypoints
 from toposort import toposort_flatten
 
+from ..plugins import constraints as plugin_constraints
 from ..config.yaml import (
     load_configuration as load_yaml_configuration,
     yaml_constructor,
@@ -96,6 +97,7 @@ def load(config_path: str):
     yield
 
 
+@plugin_constraints(required=True)
 def load_pipeline(content: list):
     """
     Load a cobald pipeline of Controller >> ... >> Pool from a configuration section

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -1,9 +1,10 @@
 import os
 from contextlib import contextmanager
-from typing import Type, Tuple
+from typing import Type, Tuple, Dict, Set
 
 from yaml import SafeLoader, BaseLoader
 from entrypoints import get_group_all as get_entrypoints
+from toposort import toposort_flatten
 
 from ..config.yaml import (
     load_configuration as load_yaml_configuration,
@@ -51,9 +52,23 @@ def load_section_plugins(entry_point_group: str) -> Tuple[SectionPlugin]:
     :param entry_point_group: entry point group to search
     :return: all loaded plugins
     """
+    plugins: Dict[str, SectionPlugin] = {
+        plugin.section: plugin
+        for plugin in
+        map(SectionPlugin.load, get_entrypoints(entry_point_group))
+    }
+    dependencies: Dict[str, Set[str]] = {
+        plugin.section: set(plugin.after)
+        for plugin in plugins.values()
+    }
+    for plugin in plugins.values():
+        for before in plugin.before:
+            dependencies[before].add(plugin.section)
     return tuple(
-        SectionPlugin.load(entry_point)
-        for entry_point in get_entrypoints(entry_point_group)
+        plugins[plugin_name]
+        for plugin_name in
+        toposort_flatten(dependencies, sort=False)
+        if plugin_name in plugins
     )
 
 

--- a/src/cobald/daemon/plugins.py
+++ b/src/cobald/daemon/plugins.py
@@ -22,12 +22,17 @@ class PluginRequirements:
         self.before = before
         self.after = after
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}"
+            f"(required={self.required},"
+            f" before={self.before},"
+            f" after={self.after})"
+        )
+
 
 def constraints(
-    *,
-    before: Iterable[str] = (),
-    after: Iterable[str] = (),
-    required: bool = False,
+    *, before: Iterable[str] = (), after: Iterable[str] = (), required: bool = False
 ):
     """
     Mark a callable as a plugin with constraints

--- a/src/cobald/daemon/plugins.py
+++ b/src/cobald/daemon/plugins.py
@@ -1,7 +1,7 @@
 """
 Tools and helpers to declare plugins
 """
-from typing import FrozenSet, TypeVar
+from typing import Iterable, FrozenSet, TypeVar
 
 
 T = TypeVar("T")
@@ -25,8 +25,8 @@ class PluginRequirements:
 
 def constraints(
     *,
-    before: FrozenSet[str] = frozenset(),
-    after: FrozenSet[str] = frozenset(),
+    before: Iterable[str] = (),
+    after: Iterable[str] = (),
     required: bool = False,
 ):
     """
@@ -44,7 +44,7 @@ def constraints(
 
     def section_wrapper(plugin: T) -> T:
         plugin.__requirements__ = PluginRequirements(
-            required=required, before=before, after=after
+            required=required, before=frozenset(before), after=frozenset(after)
         )
         return plugin
 

--- a/src/cobald/daemon/plugins.py
+++ b/src/cobald/daemon/plugins.py
@@ -1,0 +1,51 @@
+"""
+Tools and helpers to declare plugins
+"""
+from typing import FrozenSet, TypeVar
+
+
+T = TypeVar("T")
+
+
+class PluginRequirements:
+    """Requirements of a :py:class:`~.SectionPlugin`"""
+
+    __slots__ = "required", "before", "after"
+
+    def __init__(
+        self,
+        required: bool = False,
+        before: FrozenSet[str] = frozenset(),
+        after: FrozenSet[str] = frozenset(),
+    ):
+        self.required = required
+        self.before = before
+        self.after = after
+
+
+def constraints(
+    *,
+    before: FrozenSet[str] = frozenset(),
+    after: FrozenSet[str] = frozenset(),
+    required: bool = False,
+):
+    """
+    Mark a callable as a plugin with constraints
+
+    :param before: other plugins that must execute before this one
+    :param after: other plugins that must execute after this one
+    :param required: whether it is an error if the plugin does not apply
+
+    .. note::
+
+        This decorator only sets constraints of a plugin.
+        A plugin must still be registered using ``entry_points``.
+    """
+
+    def section_wrapper(plugin: T) -> T:
+        plugin.__requirements__ = PluginRequirements(
+            required=required, before=before, after=after
+        )
+        return plugin
+
+    return section_wrapper


### PR DESCRIPTION
This PR adds a new means for ordering configuration section plugins. Changes include:

* a decorator `cobald.daemon.plugins.constraints` to mark settings for a plugin,
* the ability to set ``before`` and ``after`` relations to other plugins,
* topological sorting of plugins.