### PR TITLE
weighted composite pool derives default based on supply (see issue #75)

### DIFF
--- a/cobald_tests/composite/test_weighted.py
+++ b/cobald_tests/composite/test_weighted.py
@@ -85,7 +85,7 @@ class TestWeightedComposite(object):
 
         assert composite.allocation == 0.7
 
-    @pytest.mark.parametrize('weight', ['supply', 'allocation', 'utilisation'])
+    @pytest.mark.parametrize("weight", ["supply", "allocation", "utilisation"])
     def test_fitness_fallback(self, weight):
         # empty composite should always assume perfect fitness
         composite = WeightedComposite(weight=weight)

--- a/cobald_tests/composite/test_weighted.py
+++ b/cobald_tests/composite/test_weighted.py
@@ -84,3 +84,25 @@ class TestWeightedComposite(object):
         pools[1].allocation = 0.6
 
         assert composite.allocation == 0.7
+
+    @pytest.mark.parametrize('weight', ['supply', 'allocation', 'utilisation'])
+    def test_fitness_fallback(self, weight):
+        # empty composite should always assume perfect fitness
+        composite = WeightedComposite(weight=weight)
+        assert composite.supply == 0
+        assert composite.allocation == 1
+        assert composite.utilisation == 1
+        children = [
+            FullMockPool(demand=0, supply=0, allocation=0.0, utilisation=0.0)
+            for _ in range(5)
+        ]
+        composite.children.extend(children)
+        assert composite.supply == 0
+        assert composite.allocation == 1
+        assert composite.utilisation == 1
+        # full composite fitness is correct
+        for child in children:
+            child.supply = 1
+        assert composite.supply == len(children)
+        assert composite.allocation == 0
+        assert composite.utilisation == 0

--- a/docs/source/changes/77.weighted_fallback.yaml
+++ b/docs/source/changes/77.weighted_fallback.yaml
@@ -1,0 +1,12 @@
+category: changed
+summary: "fallback for fitness of WeightedComposite depends on supply"
+description: |
+  Computing the fitness of :py:class:`~cobald.composite.weighted.WeightedComposite`
+  is undefined whenever its ``weight`` is zero. The fallback previously unconditionally
+  asserted perfect fitness -- this is not appropriate for the new weights added in #67.
+  With this change, perfect fitness is only assumed when the supply is zero, meaning
+  that fitness is truly unknown. In any other case, the actual fitness is used.
+pull requests:
+- 77
+issues:
+- 75

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
             "include",
             "entrypoints",
             "toposort",
+            "typing_extensions",
         ],
         extras_require={
             "docs": ["sphinx", "sphinxcontrib-tikz", "sphinx_rtd_theme"],

--- a/src/cobald/composite/weighted.py
+++ b/src/cobald/composite/weighted.py
@@ -1,10 +1,29 @@
+from typing_extensions import Literal
+
 from ..interfaces import Pool, CompositePool
 
 
 class WeightedComposite(CompositePool):
     """
-    Weighted composition of several pools, with each pool weighted by its
-    supply, utilisation or allocation.
+    Composition of pools weighted by their current state
+
+    The aggregation of children's :py:attr:`~.Pool.demand`,
+    :py:attr:`~.Pool.utilisation` and :py:attr:`~.Pool.allocation`
+    is weighted by each child's ``weight``.
+    Children can be weighted by their :py:attr:`~.Pool.supply`,
+    :py:attr:`~.Pool.utilisation` or :py:attr:`~.Pool.allocation`.
+    Note that weighting the :py:attr:`~.Pool.demand` only applies to
+    *distributing* it to children; the composite's :py:attr:`~.Pool.demand`
+    is always exactly as set by its controller.
+
+    If the total weight is 0, the following fallback applies:
+
+    * :py:attr:`~.Pool.demand` is applied uniformly, and
+    * :py:attr:`~.Pool.utilisation` and :py:attr:`~.Pool.allocation` are assumed
+      1 if there are no children, 0 otherwise.
+
+    The latter rule expresses that the total fitness of a Pool is 0 either if the
+    fitness of all its children is 0, or there are no children.
     """
 
     children = []
@@ -72,7 +91,7 @@ class WeightedComposite(CompositePool):
     def _total_weight(self):
         return sum(getattr(child, self._weight) for child in self.children)
 
-    def __init__(self, *children: Pool, weight="supply"):
+    def __init__(self, *children: Pool, weight: Literal["supply", "utilisation", "allocation"] = "supply"):
         assert weight in (
             "supply",
             "utilisation",

--- a/src/cobald/composite/weighted.py
+++ b/src/cobald/composite/weighted.py
@@ -38,7 +38,7 @@ class WeightedComposite(CompositePool):
                 / self._total_weight
             )
         except ZeroDivisionError:
-            return 1.0
+            return self._undefined_fitness()
 
     @property
     def allocation(self):
@@ -51,7 +51,22 @@ class WeightedComposite(CompositePool):
                 / self._total_weight
             )
         except ZeroDivisionError:
-            return 1.0
+            return self._undefined_fitness()
+
+    def _undefined_fitness(self) -> float:
+        """Fitness (allocation/utilisation) to return when weighting is zero"""
+        # There are two separate causes why we end up here:
+        # 1. supply == 0 and there is nothing that can contribute to the weight
+        # 2. weight == 0 because child pools perform that badly
+        # Notably, 2. means child performance is *bad*,
+        # whereas 1. means child performance is *undefined*.
+        #
+        # If performance is bad (2.) we need to preserve this (-> 0.0).
+        # If performance is undefined (1.) we *assume* it is good (-> 1.0) so that we
+        # eventually get real data once children exist.
+        #
+        # See also issues #75, #18
+        return 0.0 if self.supply > 0 else 1.0
 
     @property
     def _total_weight(self):

--- a/src/cobald/composite/weighted.py
+++ b/src/cobald/composite/weighted.py
@@ -94,7 +94,7 @@ class WeightedComposite(CompositePool):
     def __init__(
         self,
         *children: Pool,
-        weight: Literal["supply", "utilisation", "allocation"] = "supply"
+        weight: Literal["supply", "utilisation", "allocation"] = "supply",
     ):
         assert weight in (
             "supply",

--- a/src/cobald/composite/weighted.py
+++ b/src/cobald/composite/weighted.py
@@ -91,7 +91,11 @@ class WeightedComposite(CompositePool):
     def _total_weight(self):
         return sum(getattr(child, self._weight) for child in self.children)
 
-    def __init__(self, *children: Pool, weight: Literal["supply", "utilisation", "allocation"] = "supply"):
+    def __init__(
+        self,
+        *children: Pool,
+        weight: Literal["supply", "utilisation", "allocation"] = "supply"
+    ):
         assert weight in (
             "supply",
             "utilisation",


### PR DESCRIPTION
This PR adjusts the default fitness (allocation/utilisation) of ``WeightedComposite`` to be more sensible. Changes include:

* ``WeightedComposite.allocation`` and ``.utilisation`` default to 1.0 *only if* ``.supply == 0``.
* expanded docs on ``WeightedComposite`` behaviour.

See also #75, #67.