### PR TITLE
Maintenance/drop include

### DIFF
--- a/cobald_tests/daemon/config/test_python.py
+++ b/cobald_tests/daemon/config/test_python.py
@@ -1,0 +1,29 @@
+import tempfile
+import os
+
+from cobald.daemon.config.python import load_configuration
+
+
+def module_content(identifier):
+    return f"""\
+identifier = {identifier}
+"""
+
+
+def test_load_pyconfig():
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".py") as test_file:
+        test_file.write(module_content(0))
+        test_file.flush()
+        module = load_configuration(test_file.name)
+        assert module.identifier == 0
+
+
+def test_load_pyconfig_many():
+    modules = []
+    for ident in range(5):
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".py") as test_file:
+            test_file.write(module_content(ident))
+            test_file.flush()
+            modules.append((ident, load_configuration(test_file.name)))
+    for ident, module in modules:
+        assert ident == module.identifier

--- a/cobald_tests/daemon/config/test_python.py
+++ b/cobald_tests/daemon/config/test_python.py
@@ -1,5 +1,5 @@
 import tempfile
-import os
+import pytest
 
 from cobald.daemon.config.python import load_configuration
 
@@ -27,3 +27,12 @@ def test_load_pyconfig_many():
             modules.append((ident, load_configuration(test_file.name)))
     for ident, module in modules:
         assert ident == module.identifier
+
+
+@pytest.mark.parametrize("extension", [".pyi", ".yml", ""])
+def test_load_pyconfig_invalid(extension):
+    with pytest.raises(ValueError):
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=extension) as test_file:
+            test_file.write(module_content("'unused'"))
+            test_file.flush()
+            _ = load_configuration(test_file.name)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ if __name__ == "__main__":
         install_requires=[
             "pyyaml",
             "trio>=0.4.0",
-            "include",
             "entrypoints",
             "toposort",
             "typing_extensions",

--- a/src/cobald/daemon/config/python.py
+++ b/src/cobald/daemon/config/python.py
@@ -19,7 +19,7 @@ def load_configuration(path):
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None:
         extension = pathlib.Path(path).suffix
-        raise RuntimeError(f"Failed to load {path} of type {extension}")
+        raise RuntimeError(f"Unrecognized file type {extension} for config {path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)

--- a/src/cobald/daemon/config/python.py
+++ b/src/cobald/daemon/config/python.py
@@ -1,3 +1,4 @@
+import pathlib
 import importlib.util
 import sys
 
@@ -6,12 +7,19 @@ _loaded = -1
 
 
 def load_configuration(path):
+    """
+    Load a configuration from a module stored at ``path``
+
+    The ``path`` must end in a valid file extension for the appropriate module type,
+    such as ``.py`` or ``.pyc`` for a plaintext or bytecode python module.
+    """
     global _loaded
     current_index = _loaded = _loaded + 1
     module_name = f"<cobald config {current_index}>"
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None:
-        raise RuntimeError(f"Failed to load {path}: no import spec could be created")
+        extension = pathlib.Path(path).suffix
+        raise RuntimeError(f"Failed to load {path} of type {extension}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)

--- a/src/cobald/daemon/config/python.py
+++ b/src/cobald/daemon/config/python.py
@@ -13,6 +13,8 @@ def load_configuration(path):
 
     The ``path`` must end in a valid file extension for the appropriate module type,
     such as ``.py`` or ``.pyc`` for a plaintext or bytecode python module.
+
+    :raises ValueError: if the extension does not mark a known module type
     """
     # largely based on "Importing a source file directly"
     # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
@@ -25,7 +27,7 @@ def load_configuration(path):
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None:
         extension = pathlib.Path(path).suffix
-        raise RuntimeError(f"Unrecognized file type {extension} for config {path}")
+        raise ValueError(f"Unrecognized file extension {extension} for config {path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)

--- a/src/cobald/daemon/config/python.py
+++ b/src/cobald/daemon/config/python.py
@@ -1,5 +1,18 @@
-import include
+import importlib.util
+import sys
+
+
+_loaded = -1
 
 
 def load_configuration(path):
-    return include.path(path)
+    global _loaded
+    current_index = _loaded = _loaded + 1
+    module_name = f"<cobald config {current_index}>"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None:
+        raise RuntimeError(f"Failed to load {path}: no import spec could be created")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/src/cobald/daemon/config/python.py
+++ b/src/cobald/daemon/config/python.py
@@ -13,9 +13,15 @@ def load_configuration(path):
     The ``path`` must end in a valid file extension for the appropriate module type,
     such as ``.py`` or ``.pyc`` for a plaintext or bytecode python module.
     """
+    # largely based on "Importing a source file directly"
+    # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
     global _loaded
     current_index = _loaded = _loaded + 1
     module_name = f"<cobald config {current_index}>"
+    # the following replicates the regular import machinery:
+    #     1. create the module metadata (spec)
+    #     2. create a module object base on the metadata
+    #     3. execute the source to populate the module
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None:
         extension = pathlib.Path(path).suffix

--- a/src/cobald/daemon/config/python.py
+++ b/src/cobald/daemon/config/python.py
@@ -1,9 +1,10 @@
 import pathlib
 import importlib.util
 import sys
+import itertools
 
 
-_loaded = -1
+_unique_module_id = itertools.count()
 
 
 def load_configuration(path):
@@ -15,8 +16,7 @@ def load_configuration(path):
     """
     # largely based on "Importing a source file directly"
     # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
-    global _loaded
-    current_index = _loaded = _loaded + 1
+    current_index = next(_unique_module_id)
     module_name = f"<cobald config {current_index}>"
     # the following replicates the regular import machinery:
     #     1. create the module metadata (spec)


### PR DESCRIPTION
This PR replaces the outdated ``include`` package with the stdlib ``importlib``.

Closes #82.

See also #85 since this is a candidate for deprecation in the long run.