### PR TITLE
fix: no notice on config errors

### DIFF
--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -30,6 +30,27 @@ class TestYamlConfig:
                 assert True
             assert True
 
+    def test_load_invalid(self):
+        """Load a invalid YAML config (dangling parameter)"""
+        with NamedTemporaryFile(suffix=".yaml") as config:
+            with open(config.name, "w") as write_stream:
+                write_stream.write(
+                    """
+                    pipeline:
+                        - !LinearController
+                          low_utilisation: 0.9
+                          foo: 0
+                        - !MockPool
+                    """
+                )
+            try:
+                with load(config.name):
+                    assert False
+            except TypeError:
+                assert True
+            else:
+                assert False
+
     def test_load_dangling(self):
         """Forbid loading a YAML config with dangling content"""
         with NamedTemporaryFile(suffix=".yaml") as config:

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -22,7 +22,7 @@ class TestYamlConfig:
                     pipeline:
                         - !LinearController
                           low_utilisation: 0.9
-                          high_utilisation: 1.1
+                          high_allocation: 1.1
                         - !MockPool
                     """
                 )
@@ -39,7 +39,7 @@ class TestYamlConfig:
                     pipeline:
                         - !LinearController
                           low_utilisation: 0.9
-                          high_utilisation: 1.1
+                          high_allocation: 1.1
                         - !MockPool
                     random_things:
                         foo: bar

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -31,7 +31,7 @@ class TestYamlConfig:
             assert True
 
     def test_load_invalid(self):
-        """Load a invalid YAML config (dangling parameter)"""
+        """Load a invalid YAML config (invalid keyword argument)"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
                 write_stream.write(
@@ -43,13 +43,9 @@ class TestYamlConfig:
                         - !MockPool
                     """
                 )
-            try:
+            with pytest.raises(TypeError):
                 with load(config.name):
                     assert False
-            except TypeError:
-                assert True
-            else:
-                assert False
 
     def test_load_dangling(self):
         """Forbid loading a YAML config with dangling content"""

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -138,7 +138,7 @@ class PipelineTranslator(Translator):
             prev_item, items = None, []
             for index, item in reversed(list(enumerate(pipeline))):
                 if prev_item is not None:
-                    if hasattr(item, '__rshift__'):
+                    if hasattr(item, "__rshift__"):
                         # fully constructed object from !constructor
                         prev_item = item >> prev_item
                     else:

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -138,10 +138,10 @@ class PipelineTranslator(Translator):
             prev_item, items = None, []
             for index, item in reversed(list(enumerate(pipeline))):
                 if prev_item is not None:
-                    try:
+                    if hasattr(item, '__rshift__'):
                         # fully constructed object from !constructor
                         prev_item = item >> prev_item
-                    except TypeError:
+                    else:
                         # encoded object from __type__: constructor
                         prev_item = self.translate_hierarchy(
                             item, where="%s[%s]" % (where, index), target=prev_item


### PR DESCRIPTION
Catching the exception to decide creation method also caught config
errors.

For example:
```
- !LinearController
  foo: 0.9
- !CpuPool
```

The daemon for this configuration ran but did not create the `CpuPool`
and displayed no error message for the invalid argument `foo` for
`LinearController`. After this patch running the configuration example above
throws an exception which greatly helps to detect typos.