### PR TITLE
fix: mixed construction methods

### DIFF
--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -30,6 +30,27 @@ class TestYamlConfig:
                 assert True
             assert True
 
+    def test_load_invalid(self):
+        """Load a invalid YAML config (dangling parameter)"""
+        with NamedTemporaryFile(suffix=".yaml") as config:
+            with open(config.name, "w") as write_stream:
+                write_stream.write(
+                    """
+                    pipeline:
+                        - !LinearController
+                          low_utilisation: 0.9
+                          foo: 0
+                        - !MockPool
+                    """
+                )
+            try:
+                with load(config.name):
+                    assert False
+            except TypeError:
+                assert True
+            else:
+                assert False
+
     def test_load_dangling(self):
         """Forbid loading a YAML config with dangling content"""
         with NamedTemporaryFile(suffix=".yaml") as config:

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -22,7 +22,7 @@ class TestYamlConfig:
                     pipeline:
                         - !LinearController
                           low_utilisation: 0.9
-                          high_utilisation: 1.1
+                          high_allocation: 1.1
                         - !MockPool
                     """
                 )
@@ -39,7 +39,7 @@ class TestYamlConfig:
                     pipeline:
                         - !LinearController
                           low_utilisation: 0.9
-                          high_utilisation: 1.1
+                          high_allocation: 1.1
                         - !MockPool
                     random_things:
                         foo: bar

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -27,7 +27,8 @@ class TestYamlConfig:
                         - !MockPool
                     """
                 )
-            load(config.name)
+            with load(config.name):
+                assert True
             assert True
 
     def test_load_invalid(self):
@@ -43,8 +44,12 @@ class TestYamlConfig:
                         - !MockPool
                     """
                 )
-            with pytest.raises(TypeError):
-                load(config.name)
+            try:
+                with load(config.name):
+                    assert False
+            except TypeError:
+                assert True
+            else:
                 assert False
 
     def test_load_dangling(self):
@@ -63,8 +68,8 @@ class TestYamlConfig:
                     """
                 )
             with pytest.raises(ConfigurationError):
-                load(config.name)
-                assert False
+                with load(config.name):
+                    assert False
 
     def test_load_missing(self):
         """Forbid loading a YAML config with missing content"""
@@ -77,8 +82,8 @@ class TestYamlConfig:
                     """
                 )
             with pytest.raises(ConfigurationError):
-                load(config.name)
-                assert False
+                with load(config.name):
+                    assert False
 
     def test_load_mixed_creation(self):
         """Load a YAML config with mixed pipeline step creation methods"""
@@ -93,11 +98,11 @@ class TestYamlConfig:
                         - !MockPool
                     """
                 )
-            config = load(config.name)
-            pipeline = next(
-                content
-                for plugin, content in config.items()
-                if plugin.section == "pipeline"
-            )
-            assert isinstance(pipeline[0], LinearController)
-            assert isinstance(pipeline[0].target, MockPool)
+            with load(config.name) as config:
+                pipeline = next(
+                    content
+                    for plugin, content in config.items()
+                    if plugin.section == "pipeline"
+                )
+                assert isinstance(pipeline[0], LinearController)
+                assert isinstance(pipeline[0].target, MockPool)

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -26,8 +26,7 @@ class TestYamlConfig:
                         - !MockPool
                     """
                 )
-            with load(config.name):
-                assert True
+            load(config.name)
             assert True
 
     def test_load_invalid(self):
@@ -43,12 +42,8 @@ class TestYamlConfig:
                         - !MockPool
                     """
                 )
-            try:
-                with load(config.name):
-                    assert False
-            except TypeError:
-                assert True
-            else:
+            with pytest.raises(TypeError):
+                load(config.name)
                 assert False
 
     def test_load_dangling(self):
@@ -67,8 +62,8 @@ class TestYamlConfig:
                     """
                 )
             with pytest.raises(ConfigurationError):
-                with load(config.name):
-                    assert False
+                load(config.name)
+                assert False
 
     def test_load_missing(self):
         """Forbid loading a YAML config with missing content"""
@@ -81,5 +76,5 @@ class TestYamlConfig:
                     """
                 )
             with pytest.raises(ConfigurationError):
-                with load(config.name):
-                    assert False
+                load(config.name)
+                assert False

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -32,7 +32,7 @@ class TestYamlConfig:
             assert True
 
     def test_load_invalid(self):
-        """Load a invalid YAML config (dangling parameter)"""
+        """Load a invalid YAML config (invalid keyword argument)"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
                 write_stream.write(
@@ -44,13 +44,9 @@ class TestYamlConfig:
                         - !MockPool
                     """
                 )
-            try:
+            with pytest.raises(TypeError):
                 with load(config.name):
                     assert False
-            except TypeError:
-                assert True
-            else:
-                assert False
 
     def test_load_dangling(self):
         """Forbid loading a YAML config with dangling content"""

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -13,6 +13,7 @@ from ..config.yaml import (
 )
 from ..config.python import load_configuration as load_python_configuration
 from ..config.mapping import Translator, SectionPlugin
+from ...interfaces._partial import Partial
 
 
 class COBalDLoader(SafeLoader):
@@ -150,5 +151,8 @@ class PipelineTranslator(Translator):
                     prev_item = self.translate_hierarchy(
                         item, where="%s[%s]" % (where, index)
                     )
+                    if isinstance(prev_item, Partial):  # got form __type__
+                        prev_item = prev_item.__construct__()
+                assert(not isinstance(prev_item, Partial))
                 items.append(prev_item)
             return list(reversed(items))

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -1,5 +1,4 @@
 import os
-from contextlib import contextmanager
 from typing import Type, Tuple, Dict, Set
 
 from yaml import SafeLoader, BaseLoader
@@ -71,31 +70,32 @@ def load_section_plugins(entry_point_group: str) -> Tuple[SectionPlugin]:
     )
 
 
-@contextmanager
 def load(config_path: str):
     """
     Load a configuration and keep it alive for the given context
 
     :param config_path: path to a configuration file
     """
-    # we bind the config to _ to keep it alive
+    # we bind the config to c to keep it alive
     if os.path.splitext(config_path)[1] in (".yaml", ".yml"):
         add_constructor_plugins(
             "cobald.config.yaml_constructors", COBalDLoader  # type: ignore
         )
         config_plugins = load_section_plugins("cobald.config.sections")
-        _ = load_yaml_configuration(
+        c = load_yaml_configuration(
             config_path,
             loader=COBalDLoader,  # type: ignore
             plugins=config_plugins,
         )
     elif os.path.splitext(config_path)[1] == ".py":
-        _ = load_python_configuration(config_path)
+        c = load_python_configuration(config_path)
     else:
         raise ValueError(
             "Unknown configuration extension: %r" % os.path.splitext(config_path)[1]
         )
-    yield
+    # result returned here is only needed for unit tests. Constructors are ran
+    # when configuration is loaded and tasks are spawend by their runners
+    return c
 
 
 @plugin_constraints(required=True)

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -138,7 +138,7 @@ class PipelineTranslator(Translator):
             prev_item, items = None, []
             for index, item in reversed(list(enumerate(pipeline))):
                 if prev_item is not None:
-                    if hasattr(item, '__rshift__'):
+                    if hasattr(item, "__rshift__"):
                         # fully constructed object from !constructor
                         prev_item = item >> prev_item
                     else:

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -153,6 +153,6 @@ class PipelineTranslator(Translator):
                     )
                     if isinstance(prev_item, Partial):  # got form __type__
                         prev_item = prev_item.__construct__()
-                assert(not isinstance(prev_item, Partial))
+                assert not isinstance(prev_item, Partial)
                 items.append(prev_item)
             return list(reversed(items))

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -138,10 +138,10 @@ class PipelineTranslator(Translator):
             prev_item, items = None, []
             for index, item in reversed(list(enumerate(pipeline))):
                 if prev_item is not None:
-                    try:
+                    if hasattr(item, '__rshift__'):
                         # fully constructed object from !constructor
                         prev_item = item >> prev_item
-                    except TypeError:
+                    else:
                         # encoded object from __type__: constructor
                         prev_item = self.translate_hierarchy(
                             item, where="%s[%s]" % (where, index), target=prev_item

--- a/src/cobald/daemon/core/config.py
+++ b/src/cobald/daemon/core/config.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 from typing import Type, Tuple, Dict, Set
 
 from yaml import SafeLoader, BaseLoader
@@ -70,6 +71,7 @@ def load_section_plugins(entry_point_group: str) -> Tuple[SectionPlugin]:
     )
 
 
+@contextmanager
 def load(config_path: str):
     """
     Load a configuration and keep it alive for the given context
@@ -93,9 +95,8 @@ def load(config_path: str):
         raise ValueError(
             "Unknown configuration extension: %r" % os.path.splitext(config_path)[1]
         )
-    # result returned here is only needed for unit tests. Constructors are ran
-    # when configuration is loaded and tasks are spawend by their runners
-    return c
+    # yielded value used in tests, runtime does not use configuration result
+    yield c
 
 
 @plugin_constraints(required=True)

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -27,9 +27,9 @@ def run(configuration: str, level: str, target: str, short_format: bool):
     )
     logger.debug(cobald.__about__.__file__)
     logger.info("Using configuration %s", configuration)
-    load(configuration)
-    logger.info("Starting daemon services...")
-    runtime.accept()
+    with load(configuration):
+        logger.info("Starting daemon services...")
+        runtime.accept()
 
 
 def cli_run():

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -27,9 +27,9 @@ def run(configuration: str, level: str, target: str, short_format: bool):
     )
     logger.debug(cobald.__about__.__file__)
     logger.info("Using configuration %s", configuration)
-    with load(configuration):
-        logger.info("Starting daemon services...")
-        runtime.accept()
+    load(configuration)
+    logger.info("Starting daemon services...")
+    runtime.accept()
 
 
 def cli_run():


### PR DESCRIPTION
As mentioned in #91 there is an issue when constructing a pipeline using both `__type__` and YAML-constructors:
```
- __type__: cobald.controller.linear.LinearController
  low_utilisation: 0.9
  high_allocation: 1.1
- !MockPool
  interval: 2.0
```

This fixes the bug, but I am not sure if this is the correct way doing so.

If I understand the function of `cobald.interfaces._partial.Partial` in `PipelineTranslator.translate_hierarchy()` correctly, its purpose is to be able to configure a pipeline step in `Translator.translate_hierarchy()` with its given configuration arguments without configuring the pipeline hierarchy as well (via `target` argument or `>>` operator), which is done finally in `PipelineTranslator.translate_hierarchy()`. The bug arises from the fact, that the first pipeline step is never fully argument applied and therefore never constructed when `Partial.__rshift__` (`>>`) is not used, because the latter constructs the object implicitly. If the first pipeline step is always constructed (which is also checked by the assertion in line 156) it works.

I guess a better way to solve this issue would be to avoid using the target argument directly and always use `__rshift__`. This also affects #91. I did not try this last option and am not sure whether it would break something. Also there are no tests for both options yet, since I am unable to figure out how to check the pipeline once the configuration is parsed using `load()` or `cobald.daemon.config.yaml.load_configuration()`.