### PR TITLE
Cleanup Bundle

### DIFF
--- a/cobald_tests/decorator/test_logger.py
+++ b/cobald_tests/decorator/test_logger.py
@@ -65,12 +65,12 @@ class TestLogger(object):
             Logger(
                 target=pool,
                 name="test logger",
-                message="logging deprecated %(consumption)s"
+                message="logging deprecated %(consumption)s",
             )
         with pytest.raises(RuntimeError):
             pool = FullMockPool()
             Logger(
                 target=pool,
                 name="test logger",
-                message="logging invalid %(dummy_field)s"
+                message="logging invalid %(dummy_field)s",
             )

--- a/cobald_tests/decorator/test_logger.py
+++ b/cobald_tests/decorator/test_logger.py
@@ -2,6 +2,8 @@ import threading
 import logging
 import io
 
+import pytest
+
 from ..mock.pool import FullMockPool
 
 from cobald.decorator.logger import Logger
@@ -51,3 +53,24 @@ class TestLogger(object):
         assert chain.name == pool.__class__.__name__
         chain.name = "final"
         assert chain.name == "final"
+
+    def test_verification(self):
+        pool = FullMockPool()
+        # no warnings by default
+        with pytest.warns(None) as recorded_warnings:
+            Logger(target=pool, name="test logger")
+            assert not recorded_warnings
+        with pytest.warns(FutureWarning):
+            pool = FullMockPool()
+            Logger(
+                target=pool,
+                name="test logger",
+                message="logging deprecated %(consumption)s"
+            )
+        with pytest.raises(RuntimeError):
+            pool = FullMockPool()
+            Logger(
+                target=pool,
+                name="test logger",
+                message="logging invalid %(dummy_field)s"
+            )

--- a/cobald_tests/utility/concurrent/test_meta_runner.py
+++ b/cobald_tests/utility/concurrent/test_meta_runner.py
@@ -60,7 +60,7 @@ class TestMetaRunner(object):
                 runner.run_payload(with_raise, flavour=flavour)
 
     def test_run_coroutine(self):
-        """Test executing a subroutine"""
+        """Test executing a coroutine"""
 
         async def with_return():
             return "expected return value"

--- a/cobald_tests/utility/concurrent/test_meta_runner.py
+++ b/cobald_tests/utility/concurrent/test_meta_runner.py
@@ -43,7 +43,8 @@ class TestMetaRunner(object):
             assert bool(runner)
             runner.stop()
 
-    def test_run_subroutine(self):
+    @pytest.mark.parametrize('flavour', (threading,))
+    def test_run_subroutine(self, flavour):
         """Test executing a subroutine"""
 
         def with_return():
@@ -52,14 +53,14 @@ class TestMetaRunner(object):
         def with_raise():
             raise KeyError("expected exception")
 
-        for flavour in (threading,):
-            runner = MetaRunner()
-            result = runner.run_payload(with_return, flavour=flavour)
-            assert result == with_return()
-            with pytest.raises(KeyError):
-                runner.run_payload(with_raise, flavour=flavour)
+        runner = MetaRunner()
+        result = runner.run_payload(with_return, flavour=flavour)
+        assert result == with_return()
+        with pytest.raises(KeyError):
+            runner.run_payload(with_raise, flavour=flavour)
 
-    def test_run_coroutine(self):
+    @pytest.mark.parametrize('flavour', (asyncio, trio))
+    def test_run_coroutine(self, flavour):
         """Test executing a coroutine"""
 
         async def with_return():
@@ -68,92 +69,91 @@ class TestMetaRunner(object):
         async def with_raise():
             raise KeyError("expected exception")
 
-        for flavour in (trio, asyncio):
-            runner = MetaRunner()
-            run_in_thread(runner.run, name="test_run_coroutine %s" % flavour)
-            result = runner.run_payload(with_return, flavour=flavour)
-            assert result == trio.run(with_return)
-            with pytest.raises(KeyError):
-                runner.run_payload(with_raise, flavour=flavour)
-            runner.stop()
+        runner = MetaRunner()
+        run_in_thread(runner.run, name="test_run_coroutine %s" % flavour)
+        result = runner.run_payload(with_return, flavour=flavour)
+        assert result == trio.run(with_return)
+        with pytest.raises(KeyError):
+            runner.run_payload(with_raise, flavour=flavour)
+        runner.stop()
 
-    def test_return_subroutine(self):
+    @pytest.mark.parametrize('flavour', (threading,))
+    def test_return_subroutine(self, flavour):
         """Test that returning from subroutines aborts runners"""
 
         def with_return():
             return "unhandled return value"
 
-        for flavour in (threading,):
-            runner = MetaRunner()
-            runner.register_payload(with_return, flavour=flavour)
-            with pytest.raises(RuntimeError) as exc:
-                runner.run()
-            assert isinstance(exc.value.__cause__, OrphanedReturn)
+        runner = MetaRunner()
+        runner.register_payload(with_return, flavour=flavour)
+        with pytest.raises(RuntimeError) as exc:
+            runner.run()
+        assert isinstance(exc.value.__cause__, OrphanedReturn)
 
-    def test_return_coroutine(self):
+    @pytest.mark.parametrize('flavour', (asyncio, trio))
+    def test_return_coroutine(self, flavour):
         """Test that returning from subroutines aborts runners"""
 
         async def with_return():
             return "unhandled return value"
 
-        for flavour in (asyncio, trio):
-            runner = MetaRunner()
-            runner.register_payload(with_return, flavour=flavour)
-            with pytest.raises(RuntimeError) as exc:
-                runner.run()
-            assert isinstance(exc.value.__cause__, OrphanedReturn)
+        runner = MetaRunner()
+        runner.register_payload(with_return, flavour=flavour)
+        with pytest.raises(RuntimeError) as exc:
+            runner.run()
+        assert isinstance(exc.value.__cause__, OrphanedReturn)
 
-    def test_abort_subroutine(self):
+    @pytest.mark.parametrize('flavour', (threading,))
+    def test_abort_subroutine(self, flavour):
         """Test that failing subroutines abort runners"""
 
         def abort():
             raise TerminateRunner
 
-        for flavour in (threading,):
-            runner = MetaRunner()
-            runner.register_payload(abort, flavour=flavour)
-            with pytest.raises(RuntimeError) as exc:
-                runner.run()
-            assert isinstance(exc.value.__cause__, TerminateRunner)
+        runner = MetaRunner()
+        runner.register_payload(abort, flavour=flavour)
+        with pytest.raises(RuntimeError) as exc:
+            runner.run()
+        assert isinstance(exc.value.__cause__, TerminateRunner)
 
-            def noop():
-                return
+        def noop():
+            return
 
-            def loop():
-                while True:
-                    time.sleep(0)
+        def loop():
+            while True:
+                time.sleep(0)
 
-            runner = MetaRunner()
-            runner.register_payload(noop, loop, flavour=flavour)
-            runner.register_payload(abort, flavour=flavour)
-            with pytest.raises(RuntimeError) as exc:
-                runner.run()
-            assert isinstance(exc.value.__cause__, TerminateRunner)
+        runner = MetaRunner()
+        runner.register_payload(noop, loop, flavour=flavour)
+        runner.register_payload(abort, flavour=flavour)
+        with pytest.raises(RuntimeError) as exc:
+            runner.run()
+        assert isinstance(exc.value.__cause__, TerminateRunner)
 
-    def test_abort_coroutine(self):
+    @pytest.mark.parametrize('flavour', (asyncio, trio))
+    def test_abort_coroutine(self, flavour):
         """Test that failing coroutines abort runners"""
 
         async def abort():
             raise TerminateRunner
 
-        for flavour in (asyncio, trio):
-            runner = MetaRunner()
-            runner.register_payload(abort, flavour=flavour)
-            with pytest.raises(RuntimeError) as exc:
-                runner.run()
-            assert isinstance(exc.value.__cause__, TerminateRunner)
+        runner = MetaRunner()
+        runner.register_payload(abort, flavour=flavour)
+        with pytest.raises(RuntimeError) as exc:
+            runner.run()
+        assert isinstance(exc.value.__cause__, TerminateRunner)
 
-            async def noop():
-                return
+        async def noop():
+            return
 
-            async def loop():
-                while True:
-                    await flavour.sleep(0)
+        async def loop():
+            while True:
+                await flavour.sleep(0)
 
-            runner = MetaRunner()
+        runner = MetaRunner()
 
-            runner.register_payload(noop, loop, flavour=flavour)
-            runner.register_payload(abort, flavour=flavour)
-            with pytest.raises(RuntimeError) as exc:
-                runner.run()
-            assert isinstance(exc.value.__cause__, TerminateRunner)
+        runner.register_payload(noop, loop, flavour=flavour)
+        runner.register_payload(abort, flavour=flavour)
+        with pytest.raises(RuntimeError) as exc:
+            runner.run()
+        assert isinstance(exc.value.__cause__, TerminateRunner)

--- a/cobald_tests/utility/concurrent/test_meta_runner.py
+++ b/cobald_tests/utility/concurrent/test_meta_runner.py
@@ -72,8 +72,7 @@ class TestMetaRunner(object):
             runner = MetaRunner()
             run_in_thread(runner.run, name="test_run_coroutine %s" % flavour)
             result = runner.run_payload(with_return, flavour=flavour)
-            # TODO: can we actually get the value from with_return?
-            assert result == "expected return value"
+            assert result == trio.run(with_return)
             with pytest.raises(KeyError):
                 runner.run_payload(with_raise, flavour=flavour)
             runner.stop()

--- a/cobald_tests/utility/concurrent/test_meta_runner.py
+++ b/cobald_tests/utility/concurrent/test_meta_runner.py
@@ -43,7 +43,7 @@ class TestMetaRunner(object):
             assert bool(runner)
             runner.stop()
 
-    @pytest.mark.parametrize('flavour', (threading,))
+    @pytest.mark.parametrize("flavour", (threading,))
     def test_run_subroutine(self, flavour):
         """Test executing a subroutine"""
 
@@ -59,7 +59,7 @@ class TestMetaRunner(object):
         with pytest.raises(KeyError):
             runner.run_payload(with_raise, flavour=flavour)
 
-    @pytest.mark.parametrize('flavour', (asyncio, trio))
+    @pytest.mark.parametrize("flavour", (asyncio, trio))
     def test_run_coroutine(self, flavour):
         """Test executing a coroutine"""
 
@@ -77,7 +77,7 @@ class TestMetaRunner(object):
             runner.run_payload(with_raise, flavour=flavour)
         runner.stop()
 
-    @pytest.mark.parametrize('flavour', (threading,))
+    @pytest.mark.parametrize("flavour", (threading,))
     def test_return_subroutine(self, flavour):
         """Test that returning from subroutines aborts runners"""
 
@@ -90,7 +90,7 @@ class TestMetaRunner(object):
             runner.run()
         assert isinstance(exc.value.__cause__, OrphanedReturn)
 
-    @pytest.mark.parametrize('flavour', (asyncio, trio))
+    @pytest.mark.parametrize("flavour", (asyncio, trio))
     def test_return_coroutine(self, flavour):
         """Test that returning from subroutines aborts runners"""
 
@@ -103,7 +103,7 @@ class TestMetaRunner(object):
             runner.run()
         assert isinstance(exc.value.__cause__, OrphanedReturn)
 
-    @pytest.mark.parametrize('flavour', (threading,))
+    @pytest.mark.parametrize("flavour", (threading,))
     def test_abort_subroutine(self, flavour):
         """Test that failing subroutines abort runners"""
 
@@ -130,7 +130,7 @@ class TestMetaRunner(object):
             runner.run()
         assert isinstance(exc.value.__cause__, TerminateRunner)
 
-    @pytest.mark.parametrize('flavour', (asyncio, trio))
+    @pytest.mark.parametrize("flavour", (asyncio, trio))
     def test_abort_coroutine(self, flavour):
         """Test that failing coroutines abort runners"""
 

--- a/src/cobald/daemon/runners/meta_runner.py
+++ b/src/cobald/daemon/runners/meta_runner.py
@@ -60,6 +60,8 @@ class MetaRunner(object):
                 asyncio_main_run(root_runner=thread_runner)
             else:
                 thread_runner.run()
+        except KeyboardInterrupt:
+            self._logger.info("runner interrupted")
         except Exception as err:
             self._logger.exception("runner terminated: %s", err)
             raise RuntimeError from err

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -20,8 +20,8 @@ def _weakset_copy(ws: "weakref.WeakSet[T]") -> Set[T]:
     """Thread-safely copy all items from a weakset to a set"""
     # The various WeakSet methods are not thread-safe because they miss locking.
     # The main issue is that all copy approaches use ``__iter__``, which is not
-    # thread-safe against items being GC'd. However, we can access the actual
-    # backing real set ``ws.data`` and ``set(some_set)`` is GIL-atomic.
+    # thread-safe against items being garbage collected. However, we can access
+    # the actual backing real set ``ws.data`` and ``set(some_set)`` is GIL-atomic.
     refs = set(ws.data)
     return {item for item in (ref() for ref in refs) if item is not None}
 

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -13,7 +13,7 @@ from .guard import exclusive
 from ..debug import NameRepr
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def _weakset_copy(ws: "weakref.WeakSet[T]") -> Set[T]:

--- a/src/cobald/decorator/logger.py
+++ b/src/cobald/decorator/logger.py
@@ -106,7 +106,9 @@ class Logger(PoolDecorator):
         try:
             message % _DEPRECATION_MAP
         except KeyError as e:
-            raise RuntimeError(f"invalid {type(self).__name__} message field: {e}")
+            raise RuntimeError(
+                f"invalid {type(self).__name__} message field: {e}"
+            ) from None
         self._logger = None  # type: logging.Logger
         self.message = message
         self.name = name

--- a/src/cobald/decorator/logger.py
+++ b/src/cobald/decorator/logger.py
@@ -56,25 +56,29 @@ _LOGGER_TEST_FIELDS = _WarnMap(
 
 class Logger(PoolDecorator):
     """
-    Proxy which logs all changes of ``target.demand``
+    Log a message on every change of ``demand``
 
-    :param name: name of the underlying :py:class:`logging.Logger`
-    :param message: message to emit for every change
+    :param name: name of the :py:class:`logging.Logger` to log to
+    :param message: format for message to emit on every change
     :param level: numerical logging level
 
     The ``message`` parameter is used as a ``%``-style format string with named fields.
-    Valid named fields are
+    Valid named format fields are
 
     ``value``
-        for the new demand to set,
+        for the new demand being set,
 
     ``demand``, ``supply``, ``utilisation`` and ``allocation``
         for the current state of ``target``, and
 
     ``target``
-        for the raw ``target`` pool.
+        for the ``target`` pool itself.
 
-    For historical reasons, ``consumption`` is available as an alias of ``allocation``.
+    For example, a ``message`` of ``"adjust demand from %(demand)s to %(value)s"``
+    will log the old and new demand value.
+
+    .. deprecated:: 0.12.2
+        The ``consumption`` format field. Use ``allocation`` instead.
     """
 
     @property

--- a/src/cobald/decorator/logger.py
+++ b/src/cobald/decorator/logger.py
@@ -19,6 +19,7 @@ class _WarnValue(NamedTuple):
 
 class _WarnMap(dict):
     r"""Map raising ``warnings`` for specific keys pointing to ``_WarnValue``\ s"""
+
     def __getitem__(self, item):
         value = super().__getitem__(item)
         if isinstance(value, _WarnValue):

--- a/src/cobald/decorator/standardiser.py
+++ b/src/cobald/decorator/standardiser.py
@@ -22,14 +22,16 @@ class Standardiser(PoolDecorator):
     :param minimum: minimum ``target.demand`` allowed
     :param maximum: maximum ``target.demand`` allowed
     :param granularity: granularity of ``target.demand``
-    :param surplus: maximum by which ``target.supply`` may exceed ``target.demand``
-    :param backlog: maximum by which ``target.demand`` may exceed ``target.supply``
+    :param surplus: how much ``target.demand`` may be above ``target.supply``
+    :param backlog: how much ``target.demand`` may be below ``target.supply``
+
+    The ``supply`` and ``backlog`` clamp the ``demand`` such that
+    ``supply - backlog <= demand <= supply + surplus`` holds.
 
     The default values apply no limits at all so that isolated limits may be used.
     When several limits are set, ``granularity`` has the weakest priority,
     both ``surplus`` and ``backlog`` may limit the result of ``granularity``,
     and ``minimum`` and ``maximum`` overrule all other limits.
-    It is illegal to
     """
 
     @property


### PR DESCRIPTION
This PR includes several minor cleanup changes.

* Cleanup of `Standardiser` (closes #69)
  - implementation better expresses its intend
  - adjusted documentation to better explain ``backlog`` and ``surplus``
* Runner suppresses traceback when stopped by ``KeyboardInterrupt``/<kbd>Ctrl</kbd>+<kbd>C</kbd>
* Removed a race condition when activating service units (probably only relevant for tests)
* ``Logger`` warns about deprecated fields (closes #85)