### PR TITLE
Read config after daemon initialisation

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,5 +22,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -v --cov
+      timeout-minutes: 5
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/cobald_tests/daemon/test_service.py
+++ b/cobald_tests/daemon/test_service.py
@@ -28,7 +28,7 @@ def accept(payload: ServiceRunner, name=None):
     thread.start()
     if not payload.running.wait(1):
         payload.shutdown()
-        raise RuntimeError("%s failed to start" % payload)
+        raise RuntimeError(f"{payload} failed to start (thread {thread})")
     try:
         yield
     finally:

--- a/cobald_tests/daemon/test_service.py
+++ b/cobald_tests/daemon/test_service.py
@@ -7,7 +7,6 @@ import contextlib
 import logging
 import signal
 import os
-import sys
 
 import pytest
 

--- a/cobald_tests/daemon/test_service.py
+++ b/cobald_tests/daemon/test_service.py
@@ -7,6 +7,7 @@ import contextlib
 import logging
 import signal
 import os
+import sys
 
 import pytest
 
@@ -175,3 +176,33 @@ class TestServiceRunner(object):
         # signal.SIGINT == KeyboardInterrupt
         runner.adopt(do_raise, signal.SIGINT, flavour=flavour)
         runner.accept()
+
+    def test_loop_context(self):
+        """Test that an event loop is available when running the context"""
+        def shutdown(delay: float):
+            time.sleep(delay)
+            os.kill(os.getpid(), signal.SIGINT)
+
+        class TestContext:
+            def __init__(self):
+                self.observed = []
+
+            def __enter__(self):
+                runner.adopt(shutdown, 0.1, flavour=threading)
+                if sys.version_info[:2] >= (3, 7):
+                    try:
+                        has_loop = asyncio.get_running_loop() is not None
+                    except RuntimeError:
+                        has_loop = False
+                else:
+                    has_loop = asyncio.get_event_loop().is_running()
+                self.observed.append(has_loop)
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.observed.append(True)
+
+        runner = ServiceRunner(accept_delay=0.1)
+        test_context = TestContext()
+        runner.accept(context=test_context)
+        assert len(test_context.observed) == 2, "context did not enter and exit"
+        assert test_context.observed[0], "event loop was not ready for context"

--- a/cobald_tests/daemon/test_service.py
+++ b/cobald_tests/daemon/test_service.py
@@ -49,13 +49,16 @@ async def async_raise(what):
     sync_raise(what)
 
 
-def sync_raise_signal(what):
+def sync_raise_signal(what, sleep):
+    if sleep is not None:
+        sleep(0.01)
     logging.info(f"signal {what}")
     os.kill(os.getpid(), what)
 
 
-async def async_raise_signal(what):
-    sync_raise_signal(what)
+async def async_raise_signal(what, sleep):
+    await sleep(0.01)
+    sync_raise_signal(what, None)
 
 
 class TestServiceRunner(object):
@@ -177,5 +180,5 @@ class TestServiceRunner(object):
         runner = ServiceRunner(accept_delay=0.1)
         runner.adopt(do_sleep, 5, flavour=flavour)
         # signal.SIGINT == KeyboardInterrupt
-        runner.adopt(do_raise, signal.SIGINT, flavour=flavour)
+        runner.adopt(do_raise, signal.SIGINT, do_sleep, flavour=flavour)
         runner.accept()

--- a/cobald_tests/daemon/test_service.py
+++ b/cobald_tests/daemon/test_service.py
@@ -24,9 +24,7 @@ class TerminateRunner(Exception):
 @contextlib.contextmanager
 def accept(payload: ServiceRunner, name):
     gc.collect()
-    thread = threading.Thread(
-        target=payload.accept, name=name, daemon=True
-    )
+    thread = threading.Thread(target=payload.accept, name=name, daemon=True)
     thread.start()
     if not payload.running.wait(1):
         payload.shutdown()

--- a/cobald_tests/utility/concurrent/test_meta_runner.py
+++ b/cobald_tests/utility/concurrent/test_meta_runner.py
@@ -21,7 +21,7 @@ def threaded_run(name=None):
     thread.start()
     if not runner.running.wait(1):
         runner.stop()
-        raise RuntimeError("%s failed to start" % runner)
+        raise RuntimeError(f"{runner} failed to start (thread {thread})")
     try:
         yield runner
     finally:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+timeout = 30

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-timeout = 30
+timeout = 15

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -39,8 +39,7 @@ async def _load_services(path: str):
     """
     with load(path):
         # sleep indefinitely to wait until the runtime is aborted
-        while True:
-            await asyncio.sleep(24 * 60 * 60)
+        await asyncio.sleep(float("inf"))
 
 
 def cli_run():

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -30,7 +30,7 @@ def run(configuration: str, level: str, target: str, short_format: bool):
     logger.info("Using configuration %s", configuration)
     logger.info("Starting daemon services...")
     runtime.adopt(_load_services, configuration, flavour=asyncio)
-    runtime.accept(context=load(configuration))
+    runtime.accept()
 
 
 async def _load_services(path: str):

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -34,7 +34,9 @@ def run(configuration: str, level: str, target: str, short_format: bool):
 
 
 async def _load_services(path: str):
-    """Helper to load the configured tasks and hold created objects alive"""
+    """
+    Helper to load configured tasks once the runtime is ready and to hold objects alive
+    """
     with load(path):
         # sleep indefinitely to wait until the runtime is aborted
         while True:

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -38,7 +38,7 @@ async def _load_services(path: str):
     with load(path):
         # sleep indefinitely to wait until the runtime is aborted
         while True:
-            await asyncio.sleep(24*60*60)
+            await asyncio.sleep(24 * 60 * 60)
 
 
 def cli_run():

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -1,6 +1,7 @@
 """
 Daemon core specific to cobald
 """
+import asyncio
 import sys
 import logging
 import platform
@@ -28,7 +29,16 @@ def run(configuration: str, level: str, target: str, short_format: bool):
     logger.debug(cobald.__about__.__file__)
     logger.info("Using configuration %s", configuration)
     logger.info("Starting daemon services...")
+    runtime.adopt(_load_services, configuration, flavour=asyncio)
     runtime.accept(context=load(configuration))
+
+
+async def _load_services(path: str):
+    """Helper to load the configured tasks and hold created objects alive"""
+    with load(path):
+        # sleep indefinitely to wait until the runtime is aborted
+        while True:
+            await asyncio.sleep(24*60*60)
 
 
 def cli_run():

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -27,9 +27,8 @@ def run(configuration: str, level: str, target: str, short_format: bool):
     )
     logger.debug(cobald.__about__.__file__)
     logger.info("Using configuration %s", configuration)
-    with load(configuration):
-        logger.info("Starting daemon services...")
-        runtime.accept()
+    logger.info("Starting daemon services...")
+    runtime.accept(context=load(configuration))
 
 
 def cli_run():

--- a/src/cobald/daemon/runners/guard.py
+++ b/src/cobald/daemon/runners/guard.py
@@ -1,8 +1,12 @@
+from typing import Callable, TypeVar
 import threading
 import functools
 
 
-def exclusive(via=threading.Lock):
+C = TypeVar("C", bound=Callable)
+
+
+def exclusive(via=threading.Lock) -> Callable[[C], C]:
     """
     Mark a callable as exclusive
 
@@ -14,7 +18,7 @@ def exclusive(via=threading.Lock):
     :note: If applied to a method, it is exclusive across all instances.
     """
 
-    def make_exclusive(fnc):
+    def make_exclusive(fnc: C) -> C:
         fnc_guard = via()
 
         @functools.wraps(fnc)

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -17,6 +17,7 @@ from ..debug import NameRepr
 if sys.version_info >= (3, 7):
     from contextlib import nullcontext
 else:
+
     class nullcontext:
         __enter__ = __exit__ = lambda *args: None
 

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Set, ContextManager
+from typing import TypeVar, Set
 import logging
 import weakref
 import trio

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -2,7 +2,6 @@ from typing import TypeVar, Set
 import logging
 import weakref
 import trio
-import gc
 import functools
 import threading
 
@@ -163,10 +162,6 @@ class ServiceRunner(object):
         """
         self._must_shutdown = False
         self._logger.info("%s starting", self.__class__.__name__)
-        # force collecting objects so that defunct,
-        # migrated and overwritten services are destroyed now
-        gc.collect()
-        self._adopt_services()
         self.adopt(self._accept_services, flavour=trio)
         self._meta_runner.run()
 

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -5,13 +5,20 @@ import trio
 import gc
 import functools
 import threading
-import contextlib
+import sys
 
 from types import ModuleType
 
 from .meta_runner import MetaRunner
 from .guard import exclusive
 from ..debug import NameRepr
+
+
+if sys.version_info >= (3, 7):
+    from contextlib import nullcontext
+else:
+    class nullcontext:
+        __enter__ = __exit__ = lambda *args: None
 
 
 T = TypeVar("T")
@@ -155,7 +162,7 @@ class ServiceRunner(object):
         self._meta_runner.register_payload(payload, flavour=flavour)
 
     @exclusive()
-    def accept(self, context: ContextManager = contextlib.nullcontext()):
+    def accept(self, context: ContextManager = nullcontext()):
         """
         Start accepting synchronous, asynchronous and service payloads
 

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -1,10 +1,11 @@
-from typing import TypeVar, Set, ContextManager, Optional
+from typing import TypeVar, Set, ContextManager
 import logging
 import weakref
 import trio
 import gc
 import functools
 import threading
+import contextlib
 
 from types import ModuleType
 
@@ -154,7 +155,7 @@ class ServiceRunner(object):
         self._meta_runner.register_payload(payload, flavour=flavour)
 
     @exclusive()
-    def accept(self, context: Optional[ContextManager] = None):
+    def accept(self, context: ContextManager = contextlib.nullcontext()):
         """
         Start accepting synchronous, asynchronous and service payloads
 
@@ -176,7 +177,7 @@ class ServiceRunner(object):
         self._is_shutdown.wait()
         self._meta_runner.stop()
 
-    async def _accept_services(self, context: Optional[ContextManager] = None):
+    async def _accept_services(self, context: ContextManager):
         delay, max_delay, increase = 0.0, self.accept_delay, self.accept_delay / 10
         self._is_shutdown.clear()
         self.running.set()

--- a/src/cobald/daemon/runners/trio_runner.py
+++ b/src/cobald/daemon/runners/trio_runner.py
@@ -33,13 +33,13 @@ class TrioRunner(BaseRunner):
             trio.from_thread.run(
                 self._submit_tasks.send, payload, trio_token=self._trio_token
             )
-        except RuntimeError:
-            # trio raises RuntimeError when we are already in the trio thread
-            # just submit the task directly
-            self._submit_tasks.send_nowait(payload)
         except (trio.RunFinishedError, trio.Cancelled):
             self._logger.warning(f"discarding payload {payload} during shutdown")
             return
+        except RuntimeError:
+            # trio raises a bare RuntimeError when we are already in the trio thread
+            # just submit the task directly
+            self._submit_tasks.send_nowait(payload)
 
     def run_payload(self, payload: Callable[[], Coroutine]):
         assert self._trio_token is not None and self._submit_tasks is not None


### PR DESCRIPTION
This PR swaps the order of initialising the daemon runtime and reading the configuration.

* [x] Run the "load configuration" context as an adopted task inside the `runtime`.
* [x] Fixed a bug that prevented adding runner tasks to trio from trio.
* [x] Further changes to the unittests to counter the illusive threading issue. :/
  * It looks like a timing issue between the "kill the runners" tests and the runners actually running. I have a hunch how to fix this in the runners, but wanted to keep other code changes to a minimum for this PR – so the unittests are modified instead.

Closes #106.