### PR TITLE
Update deprecated GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6', 'pypy-3.7']

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,9 +10,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6', 'pypy-3.7']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -24,4 +24,4 @@ jobs:
         pytest -v --cov
       timeout-minutes: 5
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install dependencies


### PR DESCRIPTION
This pull request addresses potential warnings about the migration of GitHub actions from `nodejs:12` to `nodejs:16`.

Like 

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2,
actions/setup-python@v2, codecov/codecov-action@v1. 
For more information see: 
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

Fixes issue  with missing Python 3.6 on ubuntu:latest (see https://github.com/actions/runner-images/issues/6399). 