### PR TITLE
CI cleanup and general maintenance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 statistics = True
 max-line-length = 80
-ignore = E501, B008, B011, W503
+ignore = E501, B008, B011, W503, B905
 select = C,E,F,W,B,B9
 exclude = docs,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,10 @@
 name: Unit Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 10 * * 3'
 
 jobs:
   build:

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -1,6 +1,10 @@
 name: Static Checks
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 10 * * 3'
 
 jobs:
   build:

--- a/cobald_tests/controller/test_relative_supply.py
+++ b/cobald_tests/controller/test_relative_supply.py
@@ -5,19 +5,15 @@ from ..mock.pool import MockPool
 
 
 class TestRelativeSupplyController(object):
-    def test_low_scale(self):
+    def test_parameter_verification(self):
         pool = MockPool()
-        with pytest.raises(Exception):
+        with pytest.raises(AssertionError):
             RelativeSupplyController(pool, low_scale=0.9, high_scale=1.0)
 
-    def test_high_scale(self):
-        pool = MockPool()
-        with pytest.raises(Exception):
+        with pytest.raises(AssertionError):
             RelativeSupplyController(pool, low_scale=0.5, high_scale=0.9)
 
-    def test_both_scales(self):
-        pool = MockPool()
-        with pytest.raises(Exception):
+        with pytest.raises(AssertionError):
             RelativeSupplyController(pool, low_scale=1.1, high_scale=0.9)
 
     def test_adjustment(self):

--- a/src/cobald/controller/relative_supply.py
+++ b/src/cobald/controller/relative_supply.py
@@ -32,7 +32,6 @@ class RelativeSupplyController(Controller):
         assert low_utilisation <= high_allocation
         self.low_utilisation = low_utilisation
         self.high_allocation = high_allocation
-        assert low_scale <= high_scale
         assert low_scale < 1
         assert high_scale > 1
         self.low_scale = low_scale

--- a/src/cobald/controller/stepwise.py
+++ b/src/cobald/controller/stepwise.py
@@ -130,8 +130,8 @@ class UnboundStepwise(object):
 
     def __init__(self, base: ControlRule):
         self.base = base
-        self.rules = []  # type: List[Tuple[float, ControlRule]]
-        self._thresholds = set()  # type: Set[float]
+        self.rules: List[Tuple[float, ControlRule]] = []
+        self._thresholds: Set[float] = set()
 
     @overload  # noqa: F811
     def add(self, rule: ControlRule, *, supply: float) -> ControlRule:

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -160,7 +160,7 @@ class SectionPlugin(Generic[M]):
         requirements = getattr(digest, "__requirements__", PluginRequirements())
         if entry_point.extras:
             raise ValueError(
-                f"SectionPlugin entry point '{entry_point.name}':"
+                f"SectionPlugin entry point {entry_point.name!r}:"
                 f" extras are no longer supported"
             )
         return cls(section=entry_point.name, digest=digest, requirements=requirements)

--- a/src/cobald/daemon/runners/asyncio_runner.py
+++ b/src/cobald/daemon/runners/asyncio_runner.py
@@ -1,4 +1,4 @@
-from typing import Callable, Awaitable, Coroutine
+from typing import Callable, Awaitable, Coroutine, Set
 import asyncio
 
 from .base_runner import BaseRunner, OrphanedReturn
@@ -21,7 +21,7 @@ class AsyncioRunner(BaseRunner):
     # takes care of adding/removing tasks.
     def __init__(self, asyncio_loop: asyncio.AbstractEventLoop):
         super().__init__(asyncio_loop)
-        self._tasks = set()
+        self._tasks: Set[asyncio.Task] = set()
         self._payload_failure = asyncio_loop.create_future()
 
     def register_payload(self, payload: Callable[[], Awaitable]):
@@ -60,7 +60,7 @@ class AsyncioRunner(BaseRunner):
         if not self._payload_failure.done():
             self._payload_failure.set_result(None)
         while self._tasks:
-            for task in self._tasks.copy():  # type: asyncio.Task
+            for task in self._tasks.copy():
                 if task.done():
                     self._tasks.discard(task)
                     # monitored tasks only propagate cancellation and KeyboardInterrupt

--- a/src/cobald/daemon/runners/base_runner.py
+++ b/src/cobald/daemon/runners/base_runner.py
@@ -10,7 +10,7 @@ from ..debug import NameRepr
 class BaseRunner(metaclass=ABCMeta):
     """Concurrency backend on top of `asyncio`"""
 
-    flavour = None  # type: Any
+    flavour: Any
 
     def __init__(self, asyncio_loop: asyncio.AbstractEventLoop):
         self.asyncio_loop = asyncio_loop

--- a/src/cobald/daemon/runners/meta_runner.py
+++ b/src/cobald/daemon/runners/meta_runner.py
@@ -34,7 +34,8 @@ class MetaRunner(object):
             DeprecationWarning(
                 "Accessing 'MetaRunner.runners' directly is deprecated. "
                 "Use register_payload or run_payload with the correct flavour instead."
-            )
+            ),
+            stacklevel=2,
         )
         return self._runners
 

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -33,7 +33,7 @@ class ServiceUnit(object):
     :param flavour: runner flavour to use for running the service
     """
 
-    __active_units__ = weakref.WeakSet()  # type: weakref.WeakSet[ServiceUnit]
+    __active_units__: "weakref.WeakSet[ServiceUnit]" = weakref.WeakSet()
 
     def __init__(self, service, flavour):
         assert hasattr(service, "run"), "service must implement a 'run' method"
@@ -193,7 +193,7 @@ class ServiceRunner(object):
             self._is_shutdown.set()
 
     def _adopt_services(self):
-        for unit in ServiceUnit.units():  # type: ServiceUnit
+        for unit in ServiceUnit.units():
             if unit.running:
                 continue
             self._logger.info("%s adopts %s", self.__class__.__name__, NameRepr(unit))

--- a/src/cobald/decorator/logger.py
+++ b/src/cobald/decorator/logger.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Any
+from typing import NamedTuple, Any, Optional
 import logging
 import warnings
 
@@ -107,7 +107,7 @@ class Logger(PoolDecorator):
         return self._logger.name
 
     @name.setter
-    def name(self, value: str):
+    def name(self, value: Optional[str]):
         if value is None:
             value = self.target.__class__.__qualname__
         self._logger = logging.getLogger(value)
@@ -115,7 +115,7 @@ class Logger(PoolDecorator):
     def __init__(
         self,
         target: Pool,
-        name: str = None,
+        name: Optional[str] = None,
         message: str = _DEFAULT_MESSAGE,
         level: int = logging.INFO,
     ):
@@ -127,7 +127,8 @@ class Logger(PoolDecorator):
             raise RuntimeError(
                 f"invalid {type(self).__name__} message field: {e}"
             ) from None
-        self._logger = None  # type: logging.Logger
-        self.message = message
+        # set properly by self.name setter immediately afterwards
+        self._logger: logging.Logger = None  # type: ignore
         self.name = name
+        self.message = message
         self.level = level

--- a/src/cobald/decorator/logger.py
+++ b/src/cobald/decorator/logger.py
@@ -128,7 +128,7 @@ class Logger(PoolDecorator):
                 f"invalid {type(self).__name__} message field: {e}"
             ) from None
         # set properly by self.name setter immediately afterwards
-        self._logger: logging.Logger = None  # type: ignore
+        self._logger: logging.Logger
         self.name = name
         self.message = message
         self.level = level

--- a/src/cobald/interfaces/_composite.py
+++ b/src/cobald/interfaces/_composite.py
@@ -1,6 +1,5 @@
-import abc
 from typing import List
-
+import abc
 
 from ._pool import Pool
 

--- a/src/cobald/interfaces/_controller.py
+++ b/src/cobald/interfaces/_controller.py
@@ -1,5 +1,5 @@
-import abc
 from typing import TypeVar, Type
+from typing_extensions import Protocol
 
 from ._pool import Pool
 from ._partial import Partial
@@ -8,7 +8,7 @@ from ._partial import Partial
 C = TypeVar("C", bound="Controller")
 
 
-class Controller(metaclass=abc.ABCMeta):
+class Controller(Protocol):
     """
     Controller adjusting the demand in a :py:class:`~.Pool`
 

--- a/src/cobald/interfaces/_controller.py
+++ b/src/cobald/interfaces/_controller.py
@@ -1,5 +1,5 @@
 from typing import TypeVar, Type
-from typing_extensions import Protocol
+import abc
 
 from ._pool import Pool
 from ._partial import Partial
@@ -8,7 +8,7 @@ from ._partial import Partial
 C = TypeVar("C", bound="Controller")
 
 
-class Controller(Protocol):
+class Controller(metaclass=abc.ABCMeta):
     """
     Controller adjusting the demand in a :py:class:`~.Pool`
 

--- a/src/cobald/interfaces/_controller.py
+++ b/src/cobald/interfaces/_controller.py
@@ -8,7 +8,7 @@ from ._partial import Partial
 C = TypeVar("C", bound="Controller")
 
 
-class Controller(metaclass=abc.ABCMeta):
+class Controller(metaclass=abc.ABCMeta):  # noqa: B024
     """
     Controller adjusting the demand in a :py:class:`~.Pool`
 

--- a/src/cobald/interfaces/_partial.py
+++ b/src/cobald/interfaces/_partial.py
@@ -58,9 +58,7 @@ class Partial(Generic[C_co]):
         try:
             if not self.leaf:
                 args = None, *args
-            Signature.from_callable(self.ctor).bind_partial(
-                *args, **kwargs
-            )
+            Signature.from_callable(self.ctor).bind_partial(*args, **kwargs)
         except TypeError as err:
             message = err.args[0]
             raise TypeError(

--- a/src/cobald/interfaces/_partial.py
+++ b/src/cobald/interfaces/_partial.py
@@ -1,4 +1,4 @@
-from inspect import Signature, BoundArguments
+from inspect import Signature
 from typing import Type, Generic, TypeVar, TYPE_CHECKING, Union, overload
 
 from . import _pool
@@ -58,9 +58,9 @@ class Partial(Generic[C_co]):
         try:
             if not self.leaf:
                 args = None, *args
-            _ = Signature.from_callable(self.ctor).bind_partial(
+            Signature.from_callable(self.ctor).bind_partial(
                 *args, **kwargs
-            )  # type: BoundArguments
+            )
         except TypeError as err:
             message = err.args[0]
             raise TypeError(

--- a/src/cobald/interfaces/_pool.py
+++ b/src/cobald/interfaces/_pool.py
@@ -1,5 +1,6 @@
-import abc
 from typing import TypeVar, Type, TYPE_CHECKING
+from typing_extensions import Protocol
+import abc
 
 from ._partial import Partial
 
@@ -10,7 +11,7 @@ if TYPE_CHECKING:
 C = TypeVar("C", bound="Controller")
 
 
-class Pool(metaclass=abc.ABCMeta):
+class Pool(Protocol):
     """
     Individual provider for a number of indistinguishable resources
     """

--- a/src/cobald/interfaces/_pool.py
+++ b/src/cobald/interfaces/_pool.py
@@ -1,5 +1,4 @@
 from typing import TypeVar, Type, TYPE_CHECKING
-from typing_extensions import Protocol
 import abc
 
 from ._partial import Partial
@@ -11,7 +10,7 @@ if TYPE_CHECKING:
 C = TypeVar("C", bound="Controller")
 
 
-class Pool(Protocol):
+class Pool(metaclass=abc.ABCMeta):
     """
     Individual provider for a number of indistinguishable resources
     """

--- a/src/cobald/interfaces/_proxy.py
+++ b/src/cobald/interfaces/_proxy.py
@@ -1,7 +1,6 @@
 from ._pool import Pool
 from typing import TypeVar, Type
 
-
 from ._partial import Partial
 
 


### PR DESCRIPTION
This PR makes adjustment for general maintenance and to keep CI going. Major changes include:

* [x] all Static Checks passing
* [x] switch to PEP 526 annotations (i.e. use `a: SomeType = ...` instead of `a = ... # type: SomeType`)
* [x] run CI regularly
  * The cron `0 10 * * 3` is "10:00 every Wednesday"

There are no outwards facing functional changes.

I've added comments on this PR where fixes aren't obvious, mostly relating to specific flake8 checks.