### PR TITLE
Fix static tests (scheduled)

### DIFF
--- a/cobald_tests/decorator/test_logger.py
+++ b/cobald_tests/decorator/test_logger.py
@@ -59,16 +59,18 @@ class TestLogger(object):
         # no warnings by default
         with pytest.warns(None) as recorded_warnings:
             Logger(target=pool, name="test logger")
-            assert not recorded_warnings
+        assert not recorded_warnings
+
+        pool = FullMockPool()
         with pytest.warns(FutureWarning):
-            pool = FullMockPool()
             Logger(
                 target=pool,
                 name="test logger",
                 message="logging deprecated %(consumption)s",
             )
+
+        pool = FullMockPool()
         with pytest.raises(RuntimeError):
-            pool = FullMockPool()
             Logger(
                 target=pool,
                 name="test logger",


### PR DESCRIPTION
This PR fixes the current static tests as per [failed scheduled tests](https://github.com/MatterMiners/cobald/actions/runs/4935823401).

- Fix for `flake8-bugbear` check `B908`. Test assertions for raised exception now scope only the statement under tests.