### PR TITLE
Update RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,9 +3,12 @@ version: 2
 build:
   image: "latest"
 
-python:
-  version: 3
+build:
   os: "ubuntu-22.04"
+  python:
+    version: 3
+
+python:
   install:
     - method: "pip"
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: 3
+    python: "3.11"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,17 @@
+version: 2
+
+build:
+  image: "latest"
+
 python:
-   version: 3
-   pip_install: true
-   extra_requirements:
-       - docs
+  version: 3
+  os: "ubuntu-22.04"
+  install:
+    - method: "pip"
+      path: .
+      extra_requirements:
+        - "docs"
+
+sphinx:
+  builder: "html"
+  configuration: "docs/conf.py"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,8 @@ build:
 
 build:
   os: "ubuntu-22.04"
-  python:
-    version: 3
+  tools:
+    python: 3
 
 python:
   install:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,17 @@ COBalD -- the Opportunistic Balancing Daemon
     :target: http://cobald.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://travis-ci.org/MatterMiners/cobald.svg?branch=master
-    :target: https://travis-ci.org/MatterMiners/cobald
-    :alt: Test Status
+.. image:: https://badges.gitter.im/MatterMiners.png
+    :target: https://gitter.im/MatterMiners/community
+    :alt: Development and Help Chat
+
+.. image:: https://github.com/MatterMiners/cobald/actions/workflows/unittests.yml/badge.svg
+    :target: https://github.com/MatterMiners/cobald/actions/workflows/unittests.yml
+    :alt: Unit Tests (master)
+
+.. image:: https://github.com/MatterMiners/cobald/actions/workflows/verification.yml/badge.svg
+    :target: https://github.com/MatterMiners/cobald/actions/workflows/verification.yml
+    :alt: Verification (master)
 
 .. image:: https://codecov.io/gh/MatterMiners/cobald/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/MatterMiners/cobald


### PR DESCRIPTION
This PR updates the readthedocs config. Previously, an outdated config version was used which caused builds with an outdated python version.

- Update RTD to build with Py3.11
  - The generic Py3 build is not accepted in contrast to what the docs docs claim.
- Update docs badges (remove outdated, match README)

[Test Build](https://cobald.readthedocs.io/en/maintenance-docs3.8/)