### PR TITLE
Add Dependabot for outdated actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR configures dependabot to watch and update GitHub actions. No other dependencies are tracked at this point.

The configuration corresponds to the recommended default config with comments removed.

----------

This changes is motivated by [advice on CodeQL Action deprecation](https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/):

> ### Can I use Dependabot to help me with this upgrade?
> Yes, you can! For more details on how to configure Dependabot to automatically upgrade your Actions dependencies, [please see this page](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

As well as tests on my own project.