### PR TITLE
Set default reviewers for GHA-dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "maxfischer2781"
+      - "MatterMiners/review"


### PR DESCRIPTION
This PR sets default [reviewers](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers) for all GitHub Action dependabot PRs.

- I've added myself explicitly as I am the de-facto code-owner.
- No [`assignees`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees) are set as we don't usually use those either.
- I've also checked [the other options](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file) but none seem sensible right now.

It only occurred to me that this is sensible *after* going through with #129 and seeing the orphan PRs. ☹️ 