### PR TITLE
Update for automation checks

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -3,6 +3,7 @@ name: Unit Tests
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 10 * * 3'
 

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -3,6 +3,7 @@ name: Static Checks
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 10 * * 3'
 

--- a/src/cobald/daemon/runners/asyncio_runner.py
+++ b/src/cobald/daemon/runners/asyncio_runner.py
@@ -39,7 +39,7 @@ class AsyncioRunner(BaseRunner):
             result = await payload()
         except (asyncio.CancelledError, KeyboardInterrupt):
             raise
-        except BaseException as e:
+        except BaseException as e:  # noqa: B036
             failure = e
         else:
             if result is None:

--- a/src/cobald/daemon/runners/thread_runner.py
+++ b/src/cobald/daemon/runners/thread_runner.py
@@ -36,7 +36,7 @@ class ThreadRunner(BaseRunner):
     def _monitor_payload(self, payload):
         try:
             result = payload()
-        except BaseException as e:
+        except BaseException as e:  # noqa: B036
             failure = e
         else:
             if result is None:


### PR DESCRIPTION
This PR makes two automation related changes:

- The linter `flake8-bugbear` recently added B036: "Don't except `BaseException` unless you plan to re-raise it." This triggered at two points in COBalD's runners which catch all exceptions from running user-specified functions. This PR ignores both reported instances, since we do re-raise the exception eventually.
- The unittest and static test now also trigger on the [`merge_group`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group) event. This is required to [run these tests when using a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) and ensure changes broken by other PRs are not merged.