### PR TITLE
Inspection maintenance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,5 +2,5 @@
 statistics = True
 max-line-length = 80
 select = C,E,F,W,B,B9
-ignore = E203, E501, E701, E704, B008, B011, B905, W503
+ignore = E203, E501, E704, B008, B011, B905, W503
 exclude = docs,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg

--- a/.flake8
+++ b/.flake8
@@ -2,5 +2,5 @@
 statistics = True
 max-line-length = 80
 select = C,E,F,W,B,B9
-ignore = E203, E501, E704, B008, B011, B905, W503
+ignore = E203, E501, E701, E704, B008, B011, B905, W503
 exclude = docs,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 statistics = True
 max-line-length = 80
-ignore = E501, B008, B011, W503, B905
 select = C,E,F,W,B,B9
+ignore = E203, E501, E704, B008, B011, B905, W503
 exclude = docs,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg

--- a/cobald_tests/controller/test_stepwise.py
+++ b/cobald_tests/controller/test_stepwise.py
@@ -8,22 +8,19 @@ from ..mock.pool import FullMockPool
 class TestStepwise:
     def test_add(self):
         @stepwise
-        def control(pool, interval):
-            ...
+        def control(pool, interval): ...
 
         assert isinstance(control, UnboundStepwise)
 
         @control.add(supply=20)
-        def rule(pool, interval):
-            ...
+        def rule(pool, interval): ...
 
         assert isinstance(control, UnboundStepwise)
         assert isinstance(rule, FunctionType)
 
     def test_instantiate(self):
         @stepwise
-        def control(pool, interval):
-            ...
+        def control(pool, interval): ...
 
         assert isinstance(control(FullMockPool()), Stepwise)
         assert isinstance(control.s() >> FullMockPool(), Stepwise)
@@ -31,8 +28,7 @@ class TestStepwise:
         assert isinstance(control.s(interval=10) >> FullMockPool(), Stepwise)
 
         @control.add(supply=20)
-        def rule(pool, interval):
-            ...
+        def rule(pool, interval): ...
 
         assert isinstance(control(FullMockPool()), Stepwise)
         assert isinstance(control.s() >> FullMockPool(), Stepwise)

--- a/cobald_tests/controller/test_stepwise.py
+++ b/cobald_tests/controller/test_stepwise.py
@@ -8,19 +8,22 @@ from ..mock.pool import FullMockPool
 class TestStepwise:
     def test_add(self):
         @stepwise
-        def control(pool, interval): ...
+        def control(pool, interval):
+            pass
 
         assert isinstance(control, UnboundStepwise)
 
         @control.add(supply=20)
-        def rule(pool, interval): ...
+        def rule(pool, interval):
+            pass
 
         assert isinstance(control, UnboundStepwise)
         assert isinstance(rule, FunctionType)
 
     def test_instantiate(self):
         @stepwise
-        def control(pool, interval): ...
+        def control(pool, interval):
+            pass
 
         assert isinstance(control(FullMockPool()), Stepwise)
         assert isinstance(control.s() >> FullMockPool(), Stepwise)
@@ -28,7 +31,8 @@ class TestStepwise:
         assert isinstance(control.s(interval=10) >> FullMockPool(), Stepwise)
 
         @control.add(supply=20)
-        def rule(pool, interval): ...
+        def rule(pool, interval):
+            pass
 
         assert isinstance(control(FullMockPool()), Stepwise)
         assert isinstance(control.s() >> FullMockPool(), Stepwise)

--- a/cobald_tests/decorator/test_logger.py
+++ b/cobald_tests/decorator/test_logger.py
@@ -1,6 +1,7 @@
 import threading
 import logging
 import io
+import warnings
 
 import pytest
 
@@ -57,9 +58,9 @@ class TestLogger(object):
     def test_verification(self):
         pool = FullMockPool()
         # no warnings by default
-        with pytest.warns(None) as recorded_warnings:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             Logger(target=pool, name="test logger")
-        assert not recorded_warnings
 
         pool = FullMockPool()
         with pytest.warns(FutureWarning):

--- a/cobald_tests/decorator/test_logger.py
+++ b/cobald_tests/decorator/test_logger.py
@@ -57,7 +57,8 @@ class TestLogger(object):
 
     def test_verification(self):
         pool = FullMockPool()
-        # no warnings by default
+        # ensure no warnings by default
+        # see https://docs.pytest.org/en/8.0.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests  # noqa
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             Logger(target=pool, name="test logger")

--- a/cobald_tests/interfaces/test_partial.py
+++ b/cobald_tests/interfaces/test_partial.py
@@ -6,12 +6,10 @@ from ..mock.pool import FullMockPool
 
 
 class MockController(Controller):
-    def regulate(self, interval: float):
-        ...
+    def regulate(self, interval: float): ...
 
 
-class MockDecorator(PoolDecorator):
-    ...
+class MockDecorator(PoolDecorator): ...
 
 
 class TestPartial(object):

--- a/cobald_tests/interfaces/test_partial.py
+++ b/cobald_tests/interfaces/test_partial.py
@@ -6,10 +6,12 @@ from ..mock.pool import FullMockPool
 
 
 class MockController(Controller):
-    def regulate(self, interval: float): ...
+    def regulate(self, interval: float):
+        pass
 
 
-class MockDecorator(PoolDecorator): ...
+class MockDecorator(PoolDecorator):
+    pass
 
 
 class TestPartial(object):

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ if __name__ == "__main__":
                 "flake8",
                 "flake8-bugbear",
                 "black; implementation_name=='cpython'",
+                "pytest>=8.0",
                 "pytest-cov",
             ]
             + TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         python_requires=">=3.8",
         install_requires=[
             "pyyaml",
-            "trio>=0.4.0",
+            "trio",
             "entrypoints",
             "toposort",
         ],

--- a/src/cobald/__about__.py
+++ b/src/cobald/__about__.py
@@ -10,6 +10,7 @@ COBalD - the Opportunistic Balancing Daemon
 This is a **draft** for a feedback based balancing system for providing
 opportunistic resources.
 """
+
 __title__ = "cobald"
 __summary__ = "COBalD - the Opportunistic Balancing Daemon"
 __url__ = "https://github.com/MatterMiners/cobald"

--- a/src/cobald/controller/stepwise.py
+++ b/src/cobald/controller/stepwise.py
@@ -134,12 +134,12 @@ class UnboundStepwise(object):
         self._thresholds: Set[float] = set()
 
     @overload  # noqa: F811
-    def add(self, rule: ControlRule, *, supply: float) -> ControlRule:
-        ...
+    def add(self, rule: ControlRule, *, supply: float) -> ControlRule: ...
 
     @overload  # noqa: F811
-    def add(self, rule: None, *, supply: float) -> Callable[[ControlRule], ControlRule]:
-        ...
+    def add(
+        self, rule: None, *, supply: float
+    ) -> Callable[[ControlRule], ControlRule]: ...
 
     def add(self, rule: ControlRule = None, *, supply: float):  # noqa: F811
         """

--- a/src/cobald/daemon/core/logger.py
+++ b/src/cobald/daemon/core/logger.py
@@ -25,9 +25,11 @@ def initialise_logging(level: str, target: str, short_format: bool):
     handler = create_handler(target=target)
     logging.basicConfig(
         level=log_level,
-        format="%(asctime)-15s (%(process)d) %(message)s"
-        if not short_format
-        else "%(message)s",
+        format=(
+            "%(asctime)-15s (%(process)d) %(message)s"
+            if not short_format
+            else "%(message)s"
+        ),
         datefmt="%Y-%m-%d %H:%M:%S",
         handlers=[handler],
     )

--- a/src/cobald/daemon/core/main.py
+++ b/src/cobald/daemon/core/main.py
@@ -1,6 +1,7 @@
 """
 Daemon core specific to cobald
 """
+
 import asyncio
 import sys
 import logging

--- a/src/cobald/daemon/debug.py
+++ b/src/cobald/daemon/debug.py
@@ -20,9 +20,11 @@ def pretty_partial(obj: partial) -> str:
     return "partial(%s%s%s)" % (
         pretty_ref(obj.func),
         "" if not obj.args else ", ".join(repr(arg) for arg in obj.args),
-        ""
-        if not obj.keywords
-        else ", ".join("%r = %r" % (k, v) for k, v in obj.keywords.items()),
+        (
+            ""
+            if not obj.keywords
+            else ", ".join("%r = %r" % (k, v) for k, v in obj.keywords.items())
+        ),
     )
 
 

--- a/src/cobald/daemon/plugins.py
+++ b/src/cobald/daemon/plugins.py
@@ -1,6 +1,7 @@
 """
 Tools and helpers to declare plugins
 """
+
 from typing import Iterable, FrozenSet, TypeVar, NamedTuple
 
 

--- a/src/cobald/interfaces/__init__.py
+++ b/src/cobald/interfaces/__init__.py
@@ -23,6 +23,7 @@ any number of :py:class:`~.PoolDecorator` may proceed it.
     }
 
 """
+
 from ._composite import CompositePool
 from ._controller import Controller
 from ._pool import Pool

--- a/src/cobald/interfaces/_partial.py
+++ b/src/cobald/interfaces/_partial.py
@@ -39,6 +39,7 @@ class Partial(Generic[C_co]):
            creates a temporary :py:class:`~.PartialBind`. Only binding to a
            :py:class:`~.Pool` as the last element creates a concrete binding.
     """
+
     __slots__ = ("ctor", "args", "kwargs", "leaf")
 
     def __init__(self, ctor: Type[C_co], *args, __leaf__, **kwargs):
@@ -74,12 +75,12 @@ class Partial(Generic[C_co]):
         return self.ctor(*args, *self.args, **kwargs, **self.kwargs)
 
     @overload  # noqa: F811
-    def __rshift__(self, other: "Union[Owner, Pool, PartialBind[Pool]]") -> "C_co":
-        ...
+    def __rshift__(self, other: "Union[Owner, Pool, PartialBind[Pool]]") -> "C_co": ...
 
     @overload  # noqa: F811
-    def __rshift__(self, other: "Union[Partial, PartialBind]") -> "PartialBind[C_co]":
-        ...
+    def __rshift__(
+        self, other: "Union[Partial, PartialBind]"
+    ) -> "PartialBind[C_co]": ...
 
     def __rshift__(self, other):  # noqa: F811
         if isinstance(other, PartialBind):
@@ -107,6 +108,7 @@ class PartialBind(Generic[C_co]):
     This helper is used to invert the operator precedence of ``>>``,
     allowing the last pair to be bound first.
     """
+
     __slots__ = ("parent", "targets")
 
     def __init__(
@@ -118,12 +120,10 @@ class PartialBind(Generic[C_co]):
         self.targets = targets
 
     @overload  # noqa: F811
-    def __rshift__(self, other: Partial[Owner]) -> "PartialBind[C_co]":
-        ...
+    def __rshift__(self, other: Partial[Owner]) -> "PartialBind[C_co]": ...
 
     @overload  # noqa: F811
-    def __rshift__(self, other: "Pool") -> "C_co":
-        ...
+    def __rshift__(self, other: "Pool") -> "C_co": ...
 
     def __rshift__(self, other: "Union[Pool, Partial[Owner]]"):  # noqa: F811
         if isinstance(other, _pool.Pool):


### PR DESCRIPTION
This PR includes maintenance trigger by recent inspection failures. Notable changes include:

- Reformat code as per `black`'s yearly format change
- Extend flake8 config as per [black recommendations](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#flake8)
    - ignore E203 for slice whitespace
    - ignore E704 for inline type hint elipsis
- Update to Pytest8 by fixing [warning test deprecation](https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests)
- Change some do-nothing test blocks to use `pass` as opposed to `...` (which is commonly used for typing omissions only)