### PR TITLE
handle exception groups in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
             "trio",
             "entrypoints",
             "toposort",
+            "exceptiongroup",
         ],
         extras_require={
             "docs": ["sphinx", "sphinx_rtd_theme"],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(repo_base_dir, "src", "cobald", "__about__.py")) as about
 with open(os.path.join(repo_base_dir, "README.rst"), "r") as README:
     long_description = README.read()
 
-TESTS_REQUIRE = ["pytest>=4.3.0", "pytest-timeout"]
+TESTS_REQUIRE = ["pytest>=4.3.0", "pytest-timeout", "exceptiongroup"]
 
 if __name__ == "__main__":
     setup(
@@ -60,7 +60,6 @@ if __name__ == "__main__":
             "trio",
             "entrypoints",
             "toposort",
-            "exceptiongroup",
         ],
         extras_require={
             "docs": ["sphinx", "sphinx_rtd_theme"],


### PR DESCRIPTION
This PR fixes checking for the new `ExceptionGroup` which `trio` is using aggressively already. The change affects only tests.

`ExceptionGroup` is a new feature in newer Python versions that allows `async` (and other code) to throw multiple exceptions at once. `trio` uses this since its most recent release, which breaks tests that expect only a single exception. To fix this, tests now unwrap exception groups *of only one element* when checking the thrown exception.