### PR TITLE
Maintenance for GitHub Actions (20260714) 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
       - "MatterMiners/review"
     cooldown:
       default-days: 7
+    groups:
+      gha minor:
+        update-types:
+          - "minor"
+      gha patches:
+        update-types:
+          - "patch"

--- a/cobald_tests/daemon/config/test_mapping.py
+++ b/cobald_tests/daemon/config/test_mapping.py
@@ -1,3 +1,4 @@
+from typing import Any
 import random
 import sys
 
@@ -7,7 +8,7 @@ from collections import Counter
 from cobald.daemon.config.mapping import Translator, ConfigurationError
 
 
-def fqdn(obj):
+def fqdn(obj: Any)-> Any:
     """Assign an fully qualified name to an object"""
     obj.fqdn = obj.__module__ + "." + obj.__qualname__
     return obj
@@ -17,7 +18,7 @@ def fqdn(obj):
 class Construct(object):
     """Type that stores its parameters on construction"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         self.args = args
         self.kwargs = kwargs
 
@@ -26,24 +27,25 @@ class Construct(object):
 
 
 @fqdn
-def count(key):
+def count(key: str):
     _counts[key] += 1
     return _counts[key]
 
 
-_counts = Counter()
+_counts: Counter[str] = Counter()
 
 
-def counted(key):
+def counted(key: str) -> "dict[str, Any]":
     return {"__type__": count.fqdn, "__args__": [key]}
 
 
 class SomeError(Exception):
-    pass
+    """Unique error type for testing"""
 
 
 @fqdn
-def raises(exc=SomeError):
+def raises(exc: "type[BaseException]" = SomeError):
+    """Force raising an error from a call"""
     raise exc("this is an error")
 
 

--- a/cobald_tests/daemon/config/test_mapping.py
+++ b/cobald_tests/daemon/config/test_mapping.py
@@ -8,7 +8,7 @@ from collections import Counter
 from cobald.daemon.config.mapping import Translator, ConfigurationError
 
 
-def fqdn(obj: Any)-> Any:
+def fqdn(obj: Any) -> Any:
     """Assign an fully qualified name to an object"""
     obj.fqdn = obj.__module__ + "." + obj.__qualname__
     return obj
@@ -32,7 +32,7 @@ def count(key: str):
     return _counts[key]
 
 
-_counts: Counter[str] = Counter()
+_counts: "Counter[str]" = Counter()
 
 
 def counted(key: str) -> "dict[str, Any]":

--- a/cobald_tests/daemon/config/test_mapping.py
+++ b/cobald_tests/daemon/config/test_mapping.py
@@ -129,12 +129,14 @@ class TestTranslate(object):
                 {"__type__": raises.fqdn}, where="test_translate_error"
             )
         assert err.value.where == "test_translate_error"
+        assert "test_translate_error" in str(err.value)
         # make sure errors propagate up without being raised anew
         with pytest.raises(ConfigurationError) as err:
             translator.translate_hierarchy(
                 [1, {"foo": {"__type__": raises.fqdn}}], where="test_translate_error"
             )
         assert err.value.where == "test_translate_error[1].foo"
+        assert "test_translate_error[1].foo" in str(err.value)
 
     def test_lookup_failure(self):
         translator = Translator()

--- a/cobald_tests/daemon/core/test_config.py
+++ b/cobald_tests/daemon/core/test_config.py
@@ -9,7 +9,6 @@ from cobald.controller.linear import LinearController
 
 from ...mock.pool import MockPool
 
-
 # register test pool as safe for YAML configurations
 COBalDLoader.add_constructor(tag="!MockPool", constructor=yaml_constructor(MockPool))
 
@@ -48,15 +47,13 @@ class TestYamlConfig:
         """Load a valid YAML config"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !LinearController
                           low_utilisation: 0.9
                           high_allocation: 1.1
                         - !MockPool
-                    """
-                )
+                    """)
             with load(config.name):
                 assert True
             assert True
@@ -65,15 +62,13 @@ class TestYamlConfig:
         """Load a invalid YAML config (invalid keyword argument)"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !LinearController
                           low_utilisation: 0.9
                           foo: 0
                         - !MockPool
-                    """
-                )
+                    """)
             with pytest.raises(TypeError):
                 with load(config.name):
                     assert False
@@ -82,8 +77,7 @@ class TestYamlConfig:
         """Forbid loading a YAML config with dangling content"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !LinearController
                           low_utilisation: 0.9
@@ -91,8 +85,7 @@ class TestYamlConfig:
                         - !MockPool
                     random_things:
                         foo: bar
-                    """
-                )
+                    """)
             with pytest.raises(ConfigurationError):
                 with load(config.name):
                     assert False
@@ -101,12 +94,10 @@ class TestYamlConfig:
         """Forbid loading a YAML config with missing content"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     logging:
                         version: 1.0
-                    """
-                )
+                    """)
             with pytest.raises(ConfigurationError):
                 with load(config.name):
                     assert False
@@ -115,15 +106,13 @@ class TestYamlConfig:
         """Load a YAML config with mixed pipeline step creation methods"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - __type__: cobald.controller.linear.LinearController
                           low_utilisation: 0.9
                           high_allocation: 0.9
                         - !MockPool
-                    """
-                )
+                    """)
             with load(config.name) as config:
                 pipeline = get_config_section(config, "pipeline")
                 assert isinstance(pipeline[0], LinearController)
@@ -133,8 +122,7 @@ class TestYamlConfig:
         """Load !Tags with substructure"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !MockPool
                     __config_test:
@@ -146,8 +134,7 @@ class TestYamlConfig:
                             - user_name: tardis
                               scopes:
                                 - user:read
-                    """
-                )
+                    """)
             with load(config.name) as config:
                 tagged = get_config_section(config, "__config_test")["tagged"]
                 assert isinstance(tagged, TagTracker)
@@ -161,8 +148,7 @@ class TestYamlConfig:
         """Load !Tags with substructure, immediately using them"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !MockPool
                     __config_test:
@@ -170,8 +156,7 @@ class TestYamlConfig:
                           top: "top level value"
                           nested:
                             - leaf: "leaf level value"
-                    """
-                )
+                    """)
             with load(config.name) as config:
                 tagged = get_config_section(config, "__config_test")["tagged"]
                 assert isinstance(tagged, TagTracker)
@@ -184,8 +169,7 @@ class TestYamlConfig:
         """Load !Tags with substructure, lazily using them"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !MockPool
                     __config_test:
@@ -193,8 +177,7 @@ class TestYamlConfig:
                           top: "top level value"
                           nested:
                             - leaf: "leaf level value"
-                    """
-                )
+                    """)
             with load(config.name) as config:
                 tagged = get_config_section(config, "__config_test")["tagged"]
                 assert isinstance(tagged, TagTracker)
@@ -208,8 +191,7 @@ class TestYamlConfig:
         """Load !Tags with nested !Tags"""
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !MockPool
                     __config_test:
@@ -219,8 +201,7 @@ class TestYamlConfig:
                           - leaf_lazy: !TagTrackerLazy
                               nested:
                                 - leaf: "leaf level value"
-                    """
-                )
+                    """)
             with load(config.name) as config:
                 top_eager = get_config_section(config, "__config_test")["top_eager"]
                 # eager tags are evaluated eagerly
@@ -236,8 +217,7 @@ class TestYamlConfig:
         # __yaml_tag_test is provided by the cobald package
         with NamedTemporaryFile(suffix=".yaml") as config:
             with open(config.name, "w") as write_stream:
-                write_stream.write(
-                    """
+                write_stream.write("""
                     pipeline:
                         - !MockPool
                     __config_test:
@@ -245,8 +225,7 @@ class TestYamlConfig:
                             top: "top level value"
                             nested:
                             - leaf: "leaf level value"
-                    """
-                )
+                    """)
             with load(config.name) as config:
                 section = get_config_section(config, "__config_test")
                 args, kwargs = section["settings_tag"]

--- a/cobald_tests/daemon/test_service.py
+++ b/cobald_tests/daemon/test_service.py
@@ -13,7 +13,6 @@ import pytest
 
 from cobald.daemon.runners.service import ServiceRunner, service
 
-
 logging.getLogger().level = 10
 
 

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -22,7 +22,7 @@ class ConfigurationError(Exception):
         self.where = where
 
     def __str__(self) -> str:
-        where = f" {self.where!r}" if self.where is not None else ''
+        where = f" {self.where!r}" if self.where is not None else ""
         return f"invalid configuration element{where}: {self.what}"
 
 

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -17,9 +17,12 @@ M = TypeVar("M", str, int, float, bool, dict, list)
 
 class ConfigurationError(Exception):
     def __init__(self, what: Any, where: str = None):
+        super().__init__(what, where)
         self.where = where
         self.what = what
-        super().__init__("invalid configuration element '%s': %s" % (where, what))
+
+    def __str__(self) -> str:
+        return f"invalid configuration element {self.where!r}: {self.what}"
 
 
 def configure_logging(logging_mapping: dict):

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -16,13 +16,14 @@ M = TypeVar("M", str, int, float, bool, dict, list)
 
 
 class ConfigurationError(Exception):
-    def __init__(self, what: Any, where: str = None):
+    def __init__(self, what: Any, where: "str | None" = None):
         super().__init__(what, where)
-        self.where = where
         self.what = what
+        self.where = where
 
     def __str__(self) -> str:
-        return f"invalid configuration element {self.where!r}: {self.what}"
+        where = f" {self.where!r}" if self.where is not None else ''
+        return f"invalid configuration element{where}: {self.what}"
 
 
 def configure_logging(logging_mapping: dict):

--- a/src/cobald/daemon/config/mapping.py
+++ b/src/cobald/daemon/config/mapping.py
@@ -26,7 +26,7 @@ class ConfigurationError(Exception):
         return f"invalid configuration element{where}: {self.what}"
 
 
-def configure_logging(logging_mapping: dict):
+def configure_logging(logging_mapping: "dict[str, Any]"):
     _logger.info("Configuring logging")
     # > takes a default parameter, disable_existing_loggers, which defaults to True
     # > for reasons of backward compatibility. This may or may not be what you want

--- a/src/cobald/daemon/config/python.py
+++ b/src/cobald/daemon/config/python.py
@@ -3,7 +3,6 @@ import importlib.util
 import sys
 import itertools
 
-
 _unique_module_id = itertools.count()
 
 

--- a/src/cobald/daemon/config/yaml.py
+++ b/src/cobald/daemon/config/yaml.py
@@ -8,7 +8,6 @@ from .mapping import (
     SectionPlugin,
 )
 
-
 R = TypeVar("R")
 
 

--- a/src/cobald/daemon/plugins.py
+++ b/src/cobald/daemon/plugins.py
@@ -4,7 +4,6 @@ Tools and helpers to declare plugins
 
 from typing import Iterable, FrozenSet, TypeVar, NamedTuple
 
-
 T = TypeVar("T")
 
 

--- a/src/cobald/daemon/runners/base_runner.py
+++ b/src/cobald/daemon/runners/base_runner.py
@@ -108,6 +108,9 @@ class OrphanedReturn(Exception):
     """A runnable returned a value without anyone to receive it"""
 
     def __init__(self, who, value):
-        super().__init__("no caller to receive %s from %s" % (value, who))
+        super().__init__(who, value)
         self.who = who
         self.value = value
+
+    def __str__(self) -> str:
+        return f"no caller to receive {self.value} from {self.who}"

--- a/src/cobald/daemon/runners/guard.py
+++ b/src/cobald/daemon/runners/guard.py
@@ -2,7 +2,6 @@ from typing import Callable, TypeVar
 import threading
 import functools
 
-
 C = TypeVar("C", bound=Callable)
 
 

--- a/src/cobald/daemon/runners/service.py
+++ b/src/cobald/daemon/runners/service.py
@@ -11,7 +11,6 @@ from .meta_runner import MetaRunner
 from .guard import exclusive
 from ..debug import NameRepr
 
-
 T = TypeVar("T")
 
 

--- a/src/cobald/decorator/logger.py
+++ b/src/cobald/decorator/logger.py
@@ -4,7 +4,6 @@ import warnings
 
 from cobald.interfaces import Pool, PoolDecorator
 
-
 _DEFAULT_MESSAGE = (
     "demand = %(value)s "
     "[demand=%(demand)s, supply=%(supply)s, "

--- a/src/cobald/interfaces/_controller.py
+++ b/src/cobald/interfaces/_controller.py
@@ -4,7 +4,6 @@ import abc
 from ._pool import Pool
 from ._partial import Partial
 
-
 C = TypeVar("C", bound="Controller")
 
 

--- a/src/cobald/interfaces/_proxy.py
+++ b/src/cobald/interfaces/_proxy.py
@@ -3,7 +3,6 @@ from typing import TypeVar, Type
 
 from ._partial import Partial
 
-
 C = TypeVar("C", bound="PoolDecorator")
 
 

--- a/src/cobald/monitor/format_json.py
+++ b/src/cobald/monitor/format_json.py
@@ -2,7 +2,6 @@ from collections.abc import Mapping
 from logging import Formatter, LogRecord
 import json
 
-
 #: Attributes of a LogRecord.
 # See <the docs `https://docs.python.org/3/library/logging.html#logrecord-attributes`>_.
 RECORD_ATTRIBUTES = (

--- a/src/cobald/monitor/format_line.py
+++ b/src/cobald/monitor/format_line.py
@@ -4,7 +4,6 @@ from typing import Dict, Set, Union, Any, TypeVar
 
 from .format_json import RECORD_ATTRIBUTES
 
-
 T = TypeVar("T")
 
 


### PR DESCRIPTION
This PR covers maintenance of actions and tests. Major changes include:

- Add [dependabot groups](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--) for minor and patch updates to reduce noise.
  - This matches my settings for `asyncstdlib`, see example PR here: https://github.com/maxfischer2781/asyncstdlib/pull/214
- Fix code to match flake8 B042: Exception classes must pass all arguments to `super().__init__()`
  - Update unittests to naively cover new `__str__` methods
- Format code with current `black`